### PR TITLE
Refactoring of the Ensure API for enhanced readability and usability

### DIFF
--- a/src/IOKode.OpinionatedFramework.ConfigureApplication/Container.cs
+++ b/src/IOKode.OpinionatedFramework.ConfigureApplication/Container.cs
@@ -36,8 +36,8 @@ public static class Container
     /// </remarks>
     public static void Initialize()
     {
-        Ensure.InvalidOperation("The container has already been initialized. It can only be initialized once.")
-            .Boolean.IsFalse(IsInitialized);
+        Ensure.Boolean.IsFalse(IsInitialized)
+            .ElseThrowsInvalidOperation("The container has already been initialized. It can only be initialized once.");
 
         _serviceCollection.MakeReadOnly();
         _serviceProvider = _serviceCollection.BuildServiceProvider();

--- a/src/IOKode.OpinionatedFramework.Ensuring/Ensure.cs
+++ b/src/IOKode.OpinionatedFramework.Ensuring/Ensure.cs
@@ -1,45 +1,20 @@
 using System;
+using System.Runtime.CompilerServices;
 
 namespace IOKode.OpinionatedFramework.Ensuring;
 
 /// <summary>
 /// Entry point for ensuring framework.
 /// </summary>
-#pragma warning disable CS1591
-public static class Ensure
+public static partial class Ensure
 {
-    public static ArgumentThrowerHolder Argument(string paramName, string? message = null) => new(paramName, message);
-    public static ThrowerHolder Base() => new(new Exception());
-    public static ThrowerHolder Base(string message) => new(new Exception(message));
-    public static ThrowerHolder Exception(Exception ex) => new(ex);
-    public static ThrowerHolder InvalidOperation(string message) => new(new InvalidOperationException(message));
-}
-#pragma warning restore CS1591
-
-/// <summary>
-/// A specified thrower for arguments.
-/// It has a special validation that throws <see cref="ArgumentNullException"/> when object is null.
-/// In all others validation, it throws <see cref="ArgumentException"/>.
-/// </summary>
-public class ArgumentThrowerHolder : ThrowerHolder
-{
-    internal ArgumentThrowerHolder(string paramName, string? message) : base(new ArgumentException(paramName, message))
-    {
-        if (string.IsNullOrWhiteSpace(paramName))
-        {
-            throw new ArgumentNullException(paramName);
-        }
-    }
-    
     /// <summary>
-    /// Ensure an object is not null.
+    /// Ensures that the given argument object is not null.
     /// </summary>
-    /// <exception cref="ArgumentNullException">Thrown when the object is null.</exception>
-    public void NotNull(object? o)
-    {
-        if (o == null)
-        {
-            throw new ArgumentNullException();
-        }
-    }
+    /// <param name="obj">The object to check for nullity.</param>
+    /// <param name="argumentName">The name of the argument that is checked for nullity. This is automatically captured from the call site.</param>
+    /// <exception cref="ArgumentNullException">Thrown when the 'obj' argument is null.</exception>
+    public static void
+        ArgumentNotNull(object obj, [CallerArgumentExpression(nameof(obj))] string? argumentName = null) =>
+        Object.NotNull(obj).ElseThrowsNullArgument(argumentName!);
 }

--- a/src/IOKode.OpinionatedFramework.Ensuring/Ensurers/StreamEnsurer.cs
+++ b/src/IOKode.OpinionatedFramework.Ensuring/Ensurers/StreamEnsurer.cs
@@ -14,7 +14,7 @@ public static class StreamEnsurer
     /// <exception cref="ArgumentNullException">Thrown when the input stream is null.</exception>
     public static bool CanRead(Stream stream)
     {
-        Ensure.Argument(nameof(stream)).NotNull(stream);
+        Ensure.ArgumentNotNull(stream);
         return stream.CanRead;
     }
 
@@ -26,7 +26,7 @@ public static class StreamEnsurer
     /// <exception cref="ArgumentNullException">Thrown when the input stream is null.</exception>
     public static bool CanWrite(Stream stream)
     {
-        Ensure.Argument(nameof(stream)).NotNull(stream);
+        Ensure.ArgumentNotNull(stream);
         return stream.CanWrite;
     }
 
@@ -38,7 +38,7 @@ public static class StreamEnsurer
     /// <exception cref="ArgumentNullException">Thrown when the input stream is null.</exception>
     public static bool CanSeek(Stream stream)
     {
-        Ensure.Argument(nameof(stream)).NotNull(stream);
+        Ensure.ArgumentNotNull(stream);
         return stream.CanSeek;
     }
 }

--- a/src/IOKode.OpinionatedFramework.Ensuring/Ensurers/TypeEnsurer.cs
+++ b/src/IOKode.OpinionatedFramework.Ensuring/Ensurers/TypeEnsurer.cs
@@ -1,24 +1,26 @@
+using System;
+
 namespace IOKode.OpinionatedFramework.Ensuring.Ensurers;
 
 [Ensurer]
 public static class TypeEnsurer
 {
-    public static bool IsAssignableTo(System.Type value, System.Type expectedType)
+    public static bool IsAssignableTo(Type value, Type expectedType)
     {
-        Ensure.Argument(nameof(value)).NotNull(value);
-        Ensure.Argument(nameof(value)).NotNull(expectedType);
+        Ensure.ArgumentNotNull(value);
+        Ensure.ArgumentNotNull(expectedType);
 
         return value.IsAssignableTo(expectedType);
     }
 
-    public static bool IsReferenceType(System.Type value)
+    public static bool IsReferenceType(Type value)
     {
         return !IsValueType(value);
     }
 
-    public static bool IsValueType(System.Type value)
+    public static bool IsValueType(Type value)
     {
-        Ensure.Argument(nameof(value)).NotNull(value);
+        Ensure.ArgumentNotNull(value);
 
         return value.IsValueType;
     }

--- a/src/IOKode.OpinionatedFramework.Ensuring/Thrower.cs
+++ b/src/IOKode.OpinionatedFramework.Ensuring/Thrower.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace IOKode.OpinionatedFramework.Ensuring;
+
+public class Thrower
+{
+    private readonly bool _isValid;
+
+    public Thrower(bool isValid)
+    {
+        _isValid = isValid;
+    }
+
+    /// <exception cref="Exception">Thrown an exception when the validation no passes.</exception>
+    public void ElseThrows(Exception ex)
+    {
+        if (!_isValid)
+        {
+            throw ex;
+        }
+    }
+}

--- a/src/IOKode.OpinionatedFramework.Ensuring/ThrowerExtensions.cs
+++ b/src/IOKode.OpinionatedFramework.Ensuring/ThrowerExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace IOKode.OpinionatedFramework.Ensuring;
+
+public static class ThrowerExtensions
+{
+    public static void ElseThrowsNullArgument(this Thrower thrower, string argumentName)
+    {
+        thrower.ElseThrows(new ArgumentNullException(argumentName));
+    }
+
+    public static void ElseThrowsIllegalArgument(this Thrower thrower, string message, string argumentName)
+    {
+        thrower.ElseThrows(new ArgumentException(message, argumentName));
+    }
+
+    public static void ElseThrowsInvalidOperation(this Thrower thrower, string message)
+    {
+        thrower.ElseThrows(new InvalidOperationException(message));
+    }
+    
+    public static void ElseThrowsBase(this Thrower thrower, string message)
+    {
+        thrower.ElseThrows(new Exception(message));
+    }
+}

--- a/src/IOKode.OpinionatedFramework.Foundation/Emailing/Email.Builder.cs
+++ b/src/IOKode.OpinionatedFramework.Foundation/Emailing/Email.Builder.cs
@@ -211,8 +211,8 @@ public partial record Email
         /// </exception>
         public Email ToEmail()
         {
-            Ensure.InvalidOperation("Cannot build an email because there aren't any \"to\".").Enumerable.NotEmpty(_to);
-            Ensure.InvalidOperation("Cannot build an email because there aren't any \"from\".").Object.NotNull(_from);
+            Ensure.Enumerable.NotEmpty(_to).ElseThrowsInvalidOperation("Cannot build an email because there aren't any \"to\".");
+            Ensure.Object.NotNull(_from).ElseThrowsInvalidOperation("Cannot build an email because there aren't any \"from\".");
 
             _messageId ??= Emailing.MessageId.GenerateMessageId(_from!.Host);
 

--- a/src/IOKode.OpinionatedFramework.Foundation/Emailing/Email.cs
+++ b/src/IOKode.OpinionatedFramework.Foundation/Emailing/Email.cs
@@ -38,8 +38,8 @@ public partial record Email
         get => _to;
         init
         {
-            Ensure.Argument(nameof(value)).NotNull(value);
-            Ensure.Argument(nameof(value)).Enumerable.NotEmpty(value);
+            Ensure.ArgumentNotNull(value);
+            Ensure.Enumerable.NotEmpty(value).ElseThrowsIllegalArgument("The set cannot be empty.", nameof(value));
             _to = value;
         }
     }

--- a/src/IOKode.OpinionatedFramework.Foundation/Emailing/EmailAddress.cs
+++ b/src/IOKode.OpinionatedFramework.Foundation/Emailing/EmailAddress.cs
@@ -34,7 +34,7 @@ public record EmailAddress
     /// <returns>An EmailAddress object with the parsed email address and optional display name.</returns>
     public static EmailAddress Parse(string value)
     {
-        Ensure.Exception(new ArgumentNullException(nameof(value))).String.NotWhiteSpace(value);
+        Ensure.String.NotWhiteSpace(value).ElseThrowsNullArgument(nameof(value));
 
         string? displayName = null;
         string emailValue;
@@ -57,7 +57,7 @@ public record EmailAddress
             emailValue = value;
         }
 
-        Ensure.Exception(new FormatException("Email address is not valid.")).String.Email(emailValue);
+        Ensure.String.Email(emailValue).ElseThrows(new FormatException("Email address is not valid."));
 
         string[] parts = emailValue.Split('@');
         var username = parts[0];

--- a/src/IOKode.OpinionatedFramework.Foundation/Emailing/MessageId.cs
+++ b/src/IOKode.OpinionatedFramework.Foundation/Emailing/MessageId.cs
@@ -20,7 +20,7 @@ public record MessageId
     /// <exception cref="ArgumentException">Thrown when the provided value is not a valid Message-ID format.</exception>
     public MessageId(string value)
     {
-        Ensure.Argument(nameof(value), "Invalid Message-ID format.").Boolean.IsTrue(IsValidMessageId(value));
+        Ensure.Boolean.IsTrue(IsValidMessageId(value)).ElseThrowsIllegalArgument("Invalid Message-ID format.", nameof(value));
 
         Value = value;
     }

--- a/src/IOKode.OpinionatedFramework.Foundation/Locator.cs
+++ b/src/IOKode.OpinionatedFramework.Foundation/Locator.cs
@@ -40,13 +40,13 @@ public static class Locator
     /// <exception cref="InvalidOperationException">Thrown when trying to resolver a non-registered service or the container is not initialized.</exception>
     public static object Resolve(Type serviceType)
     {
-        Ensure.InvalidOperation("The container is not initialized. Call Container.Initialize().")
-            .Object.NotNull(ServiceProvider);
+        Ensure.Object.NotNull(ServiceProvider)
+            .ElseThrowsInvalidOperation("The container is not initialized. Call Container.Initialize().");
 
         var service = ServiceProvider!.GetService(serviceType);
 
-        Ensure.InvalidOperation($"No service of type '{serviceType.FullName}' has been registered.")
-            .Object.NotNull(service);
+        Ensure.Object.NotNull(service)
+            .ElseThrowsInvalidOperation($"No service of type '{serviceType.FullName}' has been registered.");
 
         return service!;
     }
@@ -59,7 +59,7 @@ public static class Locator
     /// <exception cref="InvalidOperationException">Thrown when trying to resolver a non-registered service or the container is not initialized.</exception>
     public static TService Resolve<TService>()
     {
-        var service = (TService)Resolve(typeof(TService));
+        var service = (TService) Resolve(typeof(TService));
         return service;
     }
 }

--- a/src/IOKode.OpinionatedFramework.Foundation/Persistence/IUnitOfWork.cs
+++ b/src/IOKode.OpinionatedFramework.Foundation/Persistence/IUnitOfWork.cs
@@ -14,7 +14,7 @@ public interface IUnitOfWork
     /// <exception cref="UnitOfWorkException"/>
     public TRepository GetRepository<TRepository>() where TRepository : IRepository
     {
-        var repository = (TRepository)GetRepository(typeof(TRepository));
+        var repository = (TRepository) GetRepository(typeof(TRepository));
         return repository;
     }
 
@@ -33,8 +33,15 @@ public interface IUnitOfWork
     /// <exception cref="UnitOfWorkException"/>
     public Task SaveChangesAsync(CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Verifies that the provided type implements <see cref="IRepository"/>.
+    /// </summary>
+    /// <param name="attemptedRepositoryType">The type to check for <see cref="IRepository"/> implementation.</param>
+    /// <exception cref="ArgumentException">Thrown when the provided '<paramref name="attemptedRepositoryType"/>' does not implement <see cref="IRepository"/>.</exception>
     protected void EnsureTypeIsRepository(Type attemptedRepositoryType)
     {
-        Ensure.Argument(nameof(attemptedRepositoryType)).Type.IsAssignableTo(attemptedRepositoryType, typeof(IRepository));
+        Ensure.Type.IsAssignableTo(attemptedRepositoryType, typeof(IRepository))
+            .ElseThrowsIllegalArgument($"The provided type must be a type that implements {nameof(IRepository)}.",
+                nameof(attemptedRepositoryType));
     }
 }

--- a/src/IOKode.OpinionatedFramework.Generators/EnsuringGenerator.cs
+++ b/src/IOKode.OpinionatedFramework.Generators/EnsuringGenerator.cs
@@ -47,21 +47,21 @@ namespace IOKode.OpinionatedFramework.Generators
             }
 
             var distinctClasses = classes.Distinct();
-            var throwers = _GetThrowers(compilation, distinctClasses, context.CancellationToken)
+            var ensurers = _GetEnsurers(compilation, distinctClasses, context.CancellationToken)
                 .ToList();
 
-            if (throwers.Count <= 0)
+            if (ensurers.Count <= 0)
             {
                 return;
             }
 
-            string ensurerHoldClass = _GenerateThrowerHolderClass(throwers);
-            context.AddSource("ThrowerHolder.g.cs", SourceText.From(ensurerHoldClass, Encoding.UTF8));
+            string ensureClass = _GenerateEnsureClass(ensurers);
+            context.AddSource("Ensure.g.cs", SourceText.From(ensureClass, Encoding.UTF8));
 
-            foreach (var thrower in throwers)
+            foreach (var ensurer in ensurers)
             {
-                string ensurerClass = _GenerateThrowerClass(thrower);
-                context.AddSource($"{thrower.ClassName}.g.cs", SourceText.From(ensurerClass, Encoding.UTF8));
+                string ensurerThrowerClass = _GenerateEnsurerThrowerClass(ensurer);
+                context.AddSource($"{ensurer.EnsurerThrowerClassName}.g.cs", SourceText.From(ensurerThrowerClass, Encoding.UTF8));
             }
         }
 


### PR DESCRIPTION
I've undertaken a substantial refactoring of the Ensure API with the primary aim of enhancing its usability and readability. Previously, the exception was declared before the validation check, which could have led to confusion.
This is how the old API usage looked:
```csharp
Ensure.Operation("Cannot read the stream.").Stream.CanRead(stream);
```
While functional, I found this approach counter-intuitive as it required specifying the exception first, which could lead to some confusion.

In an effort to improve the code's clarity and maintain a more natural flow, I've restructured the API to allow for validation before the exception is thrown. Here's how you can use the updated API:
```csharp
Ensure.Stream.CanRead(stream).ElseThrowsInvalidOperation("Cannot read the stream.");
```
This new structure reads more like a natural language sentence, and I believe it offers a better understanding of the code. I hope you'll find this change improves the developer experience when interacting with the API.

I've taken the liberty to update all instances where the old API usage occurred within the codebase.