### PR TITLE
fix: add missing [Flags] attribute to NumericOptions enum

### DIFF
--- a/src/Ensuring/Ensurers/StringEnsurer.cs
+++ b/src/Ensuring/Ensurers/StringEnsurer.cs
@@ -44,6 +44,7 @@ public enum AlphaOptions
 /// <summary>
 /// Defines options that determine how a numeric string should be checked for certain characteristics.
 /// </summary>
+[Flags]
 public enum NumericOptions
 {
     /// <summary>


### PR DESCRIPTION
fixes #31 
The [Flags] attribute was added to the NumericOptions enum.