### PR TITLE
Add [Flags] attribute to NumericOptions

### DIFF
--- a/src/Ensuring/Ensurers/StringEnsurer.cs
+++ b/src/Ensuring/Ensurers/StringEnsurer.cs
@@ -44,6 +44,7 @@ public enum AlphaOptions
 /// <summary>
 /// Defines options that determine how a numeric string should be checked for certain characteristics.
 /// </summary>
+[Flags]
 public enum NumericOptions
 {
     /// <summary>


### PR DESCRIPTION
Fixes #31

Add `[Flags]` attribute to `NumericOptions` enum in `src/Ensuring/Ensurers/StringEnsurer.cs`.

* Ensure `NumericOptions` enum values are bitwise compatible.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/iokode/OpinionatedFramework/pull/46?shareId=c3f5213a-2b0d-49ea-b98e-173da5305406).