### PR TITLE
fix(generators): fixes bugs on resource controller and query object generators

### DIFF
--- a/src/SourceGenerators.ResourceControllers/SourceGenerator.InfoExtraction.cs
+++ b/src/SourceGenerators.ResourceControllers/SourceGenerator.InfoExtraction.cs
@@ -23,7 +23,7 @@ public partial class SourceGenerator
             .Cast<ResourceData>();
 
         var controllersData = resourcesData
-            .GroupBy(command => command.Resource.Kebaberize())
+            .GroupBy(command => command.Resource.Pluralize().Kebaberize())
             .Select(group => new ResourceControllerData
             {
                 AssemblyNamespace = generatorData.AssemblyNamespace,

--- a/src/SourceGenerators.SqlQueryObjects/QueryObjectsGenerator.CodeGeneraton.cs
+++ b/src/SourceGenerators.SqlQueryObjects/QueryObjectsGenerator.CodeGeneraton.cs
@@ -232,7 +232,7 @@ public partial class QueryObjectsGenerator
             {{~ end ~}}
         }
 
-        public partial record {{ QueryResultClassName }}
+        {{ QueryClassAccessor }} partial record {{ QueryResultClassName }}
         {
             {{~ for parameter in ResultParameters ~}}
             public required {{ parameter.Type }} {{ parameter.PascalCaseName }} { get; init; }

--- a/src/Tests.ResourceControllers/ResourceControllersTests.cs
+++ b/src/Tests.ResourceControllers/ResourceControllersTests.cs
@@ -320,4 +320,20 @@ public class ResourceControllersTests : IClassFixture<ResourceControllersFixture
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal($"enabled-by-code-{code}", content);
     }
+    
+    [Fact]
+    public async Task ActionRenameUser_ByName_Success()
+    {
+        // Arrange
+        var name = "Angel";
+
+        // Act
+        var response = await this.client.PatchAsync($"/users/by-name/{name}/rename",
+            new StringContent(@"""Miguel""", Encoding.UTF8, "application/json"));
+
+        // Assert
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("Miguel", content);
+    }
 }

--- a/src/Tests.Resources/ListProducts.sql
+++ b/src/Tests.Resources/ListProducts.sql
@@ -1,6 +1,7 @@
 -- @generate
 -- @using IOKode.OpinionatedFramework.Resources.Attributes
--- @attribute [ListResources("product")]
 -- @result string name
+
+-- @attribute [ListResources("product")]
 
 select unnest(array['product1','product2','product3']) as name;

--- a/src/Tests.Resources/RenameUserCommand.cs
+++ b/src/Tests.Resources/RenameUserCommand.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+using IOKode.OpinionatedFramework.Commands;
+using IOKode.OpinionatedFramework.Resources.Attributes;
+
+namespace IOKode.OpinionatedFramework.Tests.Resources;
+
+[ActionOnResource( "user", "rename", "by name")]
+public class RenameUserCommand(string name, string newName) : Command<string>
+{
+    protected override Task<string> ExecuteAsync(ICommandExecutionContext executionContext)
+    {
+        return Task.FromResult(newName);
+    }
+}


### PR DESCRIPTION
In the resource controller generator, fix the issue where parameters of type CancellationToken were being annotated with arbitrary attributes. Also, add a [FromBody] attribute to the last parameter other than the resource id (if any) for Create, Update, Delete, and ActionOverResource.

In the query objects generator, the record returned as the query result is also declared as internal when the directive is added.