### PR TITLE
Support multiple result sets

### DIFF
--- a/src/ContractImplementations.NHibernate/QueryExecutor/NHibernateQueryExecutionExecutorContext.cs
+++ b/src/ContractImplementations.NHibernate/QueryExecutor/NHibernateQueryExecutionExecutorContext.cs
@@ -8,12 +8,28 @@ namespace IOKode.OpinionatedFramework.ContractImplementations.NHibernate.QueryEx
 
 public class NHibernateQueryExecutionExecutorContext : IQueryExecutionContext
 {
+    private IReadOnlyList<object> results = Array.Empty<object>();
+
     public required IDbTransaction? Transaction { get; set; }
     public required bool IsExecuted { get; set; }
+    public required bool HasMultipleResultSets { get; set; }
     public required ICollection<string> Directives { get; set; }
     public required object? Parameters { get; set; }
     public required CancellationToken CancellationToken { get; set; }
-    public required string RawQuery { get; set; }
-    public required IReadOnlyList<object> Results { get; set; }
+    public required string RawQuery { get; init; }
+    public required IReadOnlyList<IQueryResultSetExecutionContext> ResultSets { get; init; }
+    public required IReadOnlyList<object> Results
+    {
+        get
+        {
+            if (!IsExecuted)
+            {
+                throw new InvalidOperationException("The query has not been executed yet.");
+            }
+
+            return results;
+        }
+        set => results = value;
+    }
     public required Guid TraceID { get; set; }
 }

--- a/src/ContractImplementations.NHibernate/QueryExecutor/NHibernateQueryResultSetExecutionContext.cs
+++ b/src/ContractImplementations.NHibernate/QueryExecutor/NHibernateQueryResultSetExecutionContext.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using IOKode.OpinionatedFramework.Persistence.Queries;
+
+namespace IOKode.OpinionatedFramework.ContractImplementations.NHibernate.QueryExecutor;
+
+public class NHibernateQueryResultSetExecutionContext : IQueryResultSetExecutionContext
+{
+    public required string? Name { get; init; }
+    public required IReadOnlyList<string> Directives { get; init; }
+    public required QueryCardinality Cardinality { get; init; }
+    public required QueryResultShape Shape { get; init; }
+    public required Type ResultType { get; init; }
+    public required string? ScalarColumnName { get; init; }
+    public required string RawQuery { get; set; }
+    public IReadOnlyList<object> Results { get; set; } = Array.Empty<object>();
+}

--- a/src/ContractImplementations.NHibernate/QueryExecutor/QueryExecutor.cs
+++ b/src/ContractImplementations.NHibernate/QueryExecutor/QueryExecutor.cs
@@ -12,6 +12,8 @@ using IOKode.OpinionatedFramework.Persistence.Queries;
 using IOKode.OpinionatedFramework.Persistence.UnitOfWork.QueryBuilder.Exceptions;
 using IOKode.OpinionatedFramework.Utilities;
 using NHibernate;
+using NHibernate.Multi;
+using NHibernate.Transform;
 using NHibernate.Type;
 using NonUniqueResultException = IOKode.OpinionatedFramework.Persistence.UnitOfWork.QueryBuilder.Exceptions.NonUniqueResultException;
 
@@ -47,6 +49,33 @@ public class QueryExecutor(
         return results.FirstOrDefault(); // Exception related to single or default already thrown by QueryAsync
     }
 
+    public async Task<IReadOnlyList<object>> QueryResultSetsAsync(IReadOnlyList<QueryResultSet> resultSets, IReadOnlyList<string> directives, object? parameters,
+        IDbTransaction? dbTransaction = null, CancellationToken cancellationToken = default)
+    {
+        var context = new NHibernateQueryExecutionExecutorContext
+        {
+            CancellationToken = cancellationToken,
+            Directives = directives.ToList(),
+            HasMultipleResultSets = resultSets.Count > 1,
+            Parameters = parameters,
+            RawQuery = string.Join(Environment.NewLine, resultSets.Select(resultSet => resultSet.RawSql)),
+            ResultSets = CreateResultSetExecutionContexts(resultSets),
+            Results = new List<object>(),
+            Transaction = dbTransaction,
+            IsExecuted = false,
+            TraceID = Guid.NewGuid()
+        };
+        Container.Advanced.CreateScope();
+        Log.Trace("Invoking query pipeline...");
+
+        await InvokeResultSetsMiddlewarePipelineAsync(resultSets, context, 0);
+
+        Log.Trace("Invoked query pipeline.");
+        Container.Advanced.DisposeScope();
+
+        return context.IsExecuted ? context.Results : Array.Empty<object>();
+    }
+
     private async Task<IReadOnlyCollection<TResult>> QueryAsync<TResult>(ResultCardinality resultCardinality, string query, object? parameters,
         IDbTransaction? dbTransaction = null, CancellationToken cancellationToken = default)
     {
@@ -54,8 +83,27 @@ public class QueryExecutor(
         {
             CancellationToken = cancellationToken,
             Directives = SqlUtilities.GetDirectives(query).ToList(),
+            HasMultipleResultSets = false,
             Parameters = parameters,
             RawQuery = query,
+            ResultSets =
+            [
+                new NHibernateQueryResultSetExecutionContext
+                {
+                    Name = null,
+                    Directives = SqlUtilities.GetDirectives(query),
+                    Cardinality = resultCardinality switch
+                    {
+                        ResultCardinality.Single => QueryCardinality.One,
+                        ResultCardinality.SingleOrDefault => QueryCardinality.ZeroOrOne,
+                        _ => QueryCardinality.ZeroOrMore
+                    },
+                    Shape = QueryResultShape.Object,
+                    ResultType = typeof(TResult),
+                    ScalarColumnName = null,
+                    RawQuery = query,
+                }
+            ],
             Results = new List<object>(),
             Transaction = dbTransaction,
             IsExecuted = false,
@@ -69,7 +117,7 @@ public class QueryExecutor(
         Log.Trace("Invoked query pipeline.");
         Container.Advanced.DisposeScope();
 
-        var results = context.Results.Cast<TResult>().ToList();
+        var results = context.IsExecuted ? context.Results.Cast<TResult>().ToList() : new List<TResult>();
         return results;
     }
 
@@ -86,34 +134,159 @@ public class QueryExecutor(
         await middleware.ExecuteAsync(context, () => InvokeMiddlewarePipelineAsync<TResult>(resultCardinality, context, index + 1));
     }
 
+    private async Task InvokeResultSetsMiddlewarePipelineAsync(IReadOnlyList<QueryResultSet> resultSets,
+        NHibernateQueryExecutionExecutorContext context, int index)
+    {
+        if (index >= middlewares.Length)
+        {
+            await ExecuteResultSetsQueryAsync(resultSets, context);
+            return;
+        }
+
+        var middleware = middlewares[index];
+        await middleware.ExecuteAsync(context, () => InvokeResultSetsMiddlewarePipelineAsync(resultSets, context, index + 1));
+    }
+
     private async Task ExecuteQueryAsync<TResult>(ResultCardinality resultCardinality, NHibernateQueryExecutionExecutorContext context)
     {
         using var session = context.Transaction == null
             ? sessionFactory.OpenStatelessSession()
             : sessionFactory.OpenStatelessSession(context.Transaction.Connection as DbConnection);
 
-        var sqlQuery = session.CreateSQLQuery(context.RawQuery);
+        var resultSet = context.ResultSets.Single();
+        var sqlQuery = session.CreateSQLQuery(resultSet.RawQuery);
 
         AddScalarsForType<TResult>(sqlQuery);
         sqlQuery.SetResultTransformer(configuration.GetResultTransformer<TResult>());
 
         if (context.Parameters != null)
         {
-            AddParameters(sqlQuery, context.Parameters);
+            AddParameters(sqlQuery, context.Parameters, resultSet.RawQuery, false);
         }
 
-        context.Results = (await sqlQuery.ListAsync<object>(context.CancellationToken)).ToArray();
+        var results = (await sqlQuery.ListAsync<object>(context.CancellationToken)).ToArray();
+        context.Results = results;
+        ((NHibernateQueryResultSetExecutionContext)resultSet).Results = results;
         context.IsExecuted = true;
 
-        if (resultCardinality is ResultCardinality.Single or ResultCardinality.SingleOrDefault && context.Results.Count > 1)
+        if (resultCardinality is ResultCardinality.Single or ResultCardinality.SingleOrDefault && results.Length > 1)
         {
             throw new NonUniqueResultException();
         }
 
-        if (resultCardinality is ResultCardinality.Single && context.Results.Count == 0)
+        if (resultCardinality is ResultCardinality.Single && results.Length == 0)
         {
             throw new EmptyResultException();
         }
+    }
+
+    private async Task ExecuteResultSetsQueryAsync(IReadOnlyList<QueryResultSet> resultSets, NHibernateQueryExecutionExecutorContext context)
+    {
+        using var session = context.Transaction == null
+            ? sessionFactory.OpenStatelessSession()
+            : sessionFactory.OpenStatelessSession(context.Transaction.Connection as DbConnection);
+
+        resultSets = CreateResultSetsFromExecutionContext(context);
+
+        if (resultSets.Count == 1)
+        {
+            var result = await ExecuteSingleResultSetQueryAsync(session, resultSets[0], context);
+            context.Results = new[] { result };
+            context.IsExecuted = true;
+            return;
+        }
+
+        var batch = session.CreateQueryBatch();
+        for (int i = 0; i < resultSets.Count; i++)
+        {
+            var resultSet = resultSets[i];
+            var sqlQuery = session.CreateSQLQuery(resultSet.RawSql);
+            ConfigureResultSetQuery(sqlQuery, resultSet);
+
+            if (context.Parameters != null)
+            {
+                AddParameters(sqlQuery, context.Parameters, resultSet.RawSql, true);
+            }
+
+            AddQueryToBatch(batch, i.ToString(), resultSet.ResultType, sqlQuery);
+        }
+
+        await batch.ExecuteAsync(context.CancellationToken);
+
+        var results = new List<object>();
+        for (int i = 0; i < resultSets.Count; i++)
+        {
+            var resultSet = resultSets[i];
+            var result = await GetBatchResultAsync(batch, i, resultSet.ResultType, context.CancellationToken);
+            EnsureCardinality(resultSet.Cardinality, GetCount(result));
+            results.Add(result);
+            ((NHibernateQueryResultSetExecutionContext)context.ResultSets[i]).Results = ((System.Collections.IEnumerable)result).Cast<object>().ToList();
+        }
+
+        context.Results = results;
+        context.IsExecuted = true;
+    }
+
+    private static IReadOnlyList<IQueryResultSetExecutionContext> CreateResultSetExecutionContexts(IReadOnlyList<QueryResultSet> resultSets)
+    {
+        return resultSets
+            .Select(resultSet => new NHibernateQueryResultSetExecutionContext
+            {
+                Name = resultSet.Name,
+                Directives = resultSet.Directives,
+                Cardinality = resultSet.Cardinality,
+                Shape = resultSet.Shape,
+                ResultType = resultSet.ResultType,
+                ScalarColumnName = resultSet.ScalarColumnName,
+                RawQuery = resultSet.RawSql,
+            })
+            .ToList();
+    }
+
+    private static IReadOnlyList<QueryResultSet> CreateResultSetsFromExecutionContext(NHibernateQueryExecutionExecutorContext context)
+    {
+        return context.ResultSets
+            .Select(resultSet => new QueryResultSet
+            {
+                Name = resultSet.Name,
+                RawSql = resultSet.RawQuery,
+                Directives = resultSet.Directives,
+                Cardinality = resultSet.Cardinality,
+                Shape = resultSet.Shape,
+                ResultType = resultSet.ResultType,
+                ScalarColumnName = resultSet.ScalarColumnName,
+            })
+            .ToList();
+    }
+
+    private async Task<object> ExecuteSingleResultSetQueryAsync(IStatelessSession session, QueryResultSet resultSet,
+        NHibernateQueryExecutionExecutorContext context)
+    {
+        var method = typeof(QueryExecutor)
+            .GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)
+            .Single(method => method.Name == nameof(ExecuteSingleResultSetQueryAsync)
+                              && method.IsGenericMethodDefinition
+                              && method.GetParameters().Length == 3);
+
+        var task = (Task<object>)method.MakeGenericMethod(resultSet.ResultType).Invoke(this, new object[] { session, resultSet, context })!;
+        return await task;
+    }
+
+    private async Task<object> ExecuteSingleResultSetQueryAsync<TResult>(IStatelessSession session, QueryResultSet resultSet,
+        NHibernateQueryExecutionExecutorContext context)
+    {
+        var sqlQuery = session.CreateSQLQuery(resultSet.RawSql);
+        ConfigureResultSetQuery(sqlQuery, resultSet);
+
+        if (context.Parameters != null)
+        {
+            AddParameters(sqlQuery, context.Parameters, resultSet.RawSql, false);
+        }
+
+        var results = (await sqlQuery.ListAsync<TResult>(context.CancellationToken)).ToList();
+        EnsureCardinality(resultSet.Cardinality, results.Count);
+        ((NHibernateQueryResultSetExecutionContext)context.ResultSets.Single()).Results = results.Cast<object>().ToList();
+        return results;
     }
 
     /// <summary>
@@ -139,15 +312,54 @@ public class QueryExecutor(
         }
     }
 
+    private void ConfigureResultSetQuery(ISQLQuery query, QueryResultSet resultSet)
+    {
+        if (resultSet.Shape == QueryResultShape.Scalar)
+        {
+            if (string.IsNullOrWhiteSpace(resultSet.ScalarColumnName))
+            {
+                throw new QueryDefinitionException("Scalar result sets must declare a scalar column name.");
+            }
+
+            query.AddScalar(configuration.TransformAlias(resultSet.ScalarColumnName), GetNHTypeFor(resultSet.ResultType));
+            return;
+        }
+
+        AddScalarsForType(query, resultSet.ResultType);
+        query.SetResultTransformer(GetResultTransformer(resultSet.ResultType));
+    }
+
+    private void AddScalarsForType(ISQLQuery query, Type resultType)
+    {
+        var props = resultType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanWrite)
+            .ToList();
+
+        foreach (var prop in props)
+        {
+            string alias = configuration.TransformAlias(prop.Name);
+            var nhType = GetNHTypeFor(prop.PropertyType);
+            query.AddScalar(alias, nhType);
+        }
+    }
+
+    private IResultTransformer GetResultTransformer(Type resultType)
+    {
+        var method = typeof(IQueryExecutorConfiguration).GetMethod(nameof(IQueryExecutorConfiguration.GetResultTransformer))!;
+        return (IResultTransformer)method.MakeGenericMethod(resultType).Invoke(configuration, Array.Empty<object?>())!;
+    }
+
     /// <summary>
     /// Maps a .NET type to the corresponding NHibernate IType. Uses either custom mappings
     /// defined in ConventionMaps or NHibernate's built-in type guessing mechanism.
     /// </summary>
     /// <param name="propertyType">The .NET type for which the NHibernate IType is being resolved.</param>
     /// <returns>The NHibernate IType that corresponds to the specified .NET type.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if the specified .NET type cannot be resolved to a supported NHibernate IType.</exception>
+    /// <exception cref="QueryDefinitionException">Thrown if the specified .NET type cannot be resolved to a supported NHibernate IType.</exception>
     private static IType GetNHTypeFor(Type propertyType)
     {
+        propertyType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+
         var nhUserType = UserTypeMapper.GetNhUserType(propertyType);
         if (nhUserType != null)
         {
@@ -156,7 +368,7 @@ public class QueryExecutor(
 
         // Fallback: Use NHibernateUtil to resolve built-in types or throw an exception for unsupported types.
         return NHibernateUtil.GuessType(propertyType) ??
-               throw new InvalidOperationException($"Unsupported type: {propertyType.FullName}");
+               throw new QueryDefinitionException($"Unsupported query type: {propertyType.FullName}");
     }
 
     /// <summary>
@@ -164,14 +376,66 @@ public class QueryExecutor(
     /// If your "parameters" object has properties that match named parameters in the SQL (e.g. :id), 
     /// you can set them.
     /// </summary>
-    private void AddParameters(ISQLQuery query, object parameters)
+    private void AddParameters(ISQLQuery query, object parameters, string rawQuery, bool ignoreMissingParameters)
     {
         var paramProps = parameters.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
         foreach (var prop in paramProps)
         {
             var paramName = configuration.TransformParameterName(prop.Name);
+            if (ignoreMissingParameters && !rawQuery.Contains($":{paramName}"))
+            {
+                continue;
+            }
+
             var value = prop.GetValue(parameters, null);
             query.SetParameter(paramName, value, GetNHTypeFor(prop.PropertyType));
         }
+    }
+
+    private static void AddQueryToBatch(IQueryBatch batch, string key, Type resultType, IQuery query)
+    {
+        var method = typeof(QueryBatchExtensions)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(method => method.Name == nameof(QueryBatchExtensions.Add)
+                              && method.IsGenericMethodDefinition
+                              && method.GetParameters().Length == 3
+                              && method.GetParameters()[0].ParameterType == typeof(IQueryBatch)
+                              && method.GetParameters()[1].ParameterType == typeof(string)
+                              && method.GetParameters()[2].ParameterType == typeof(IQuery));
+
+        method.MakeGenericMethod(resultType).Invoke(null, new object[] { batch, key, query });
+    }
+
+    private static async Task<object> GetBatchResultAsync(IQueryBatch batch, int index, Type resultType, CancellationToken cancellationToken)
+    {
+        var method = typeof(IQueryBatch)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Single(method => method.Name == nameof(IQueryBatch.GetResultAsync)
+                              && method.IsGenericMethodDefinition
+                              && method.GetParameters().Length == 2
+                              && method.GetParameters()[0].ParameterType == typeof(int));
+
+        var task = (Task)method.MakeGenericMethod(resultType).Invoke(batch, new object[] { index, cancellationToken })!;
+        await task;
+
+        return task.GetType().GetProperty(nameof(Task<object>.Result))!.GetValue(task)!;
+    }
+
+    private static void EnsureCardinality(QueryCardinality cardinality, int resultCount)
+    {
+        if (cardinality is QueryCardinality.One or QueryCardinality.ZeroOrOne && resultCount > 1)
+        {
+            throw new NonUniqueResultException();
+        }
+
+        if (cardinality is QueryCardinality.One && resultCount == 0)
+        {
+            throw new EmptyResultException();
+        }
+    }
+
+    private static int GetCount(object result)
+    {
+        return (int)result.GetType().GetProperty(nameof(IReadOnlyCollection<object>.Count))!.GetValue(result)!;
     }
 }

--- a/src/ContractImplementations.NHibernate/QueryExecutor/QueryExecutorOptions.cs
+++ b/src/ContractImplementations.NHibernate/QueryExecutor/QueryExecutorOptions.cs
@@ -6,5 +6,5 @@ namespace IOKode.OpinionatedFramework.ContractImplementations.NHibernate.QueryEx
 public class QueryExecutorOptions
 {
     public IQueryExecutorConfiguration? QueryExecutorConfiguration { get; set; }
-    public List<QueryMiddleware> Middlewares { get; set; } = [];
+    public List<QueryMiddleware> Middlewares { get; set; } = new();
 }

--- a/src/Foundation/Persistence/Queries/IQuery.cs
+++ b/src/Foundation/Persistence/Queries/IQuery.cs
@@ -4,25 +4,27 @@ using System.Collections.Generic;
 namespace IOKode.OpinionatedFramework.Persistence.Queries;
 
 /// <summary>
-/// Represents a query object that describes a SQL query and its public result type.
+/// Represents a query object that describes the original SQL text, its global directives, its result sets,
+/// and its public result type.
 /// </summary>
 /// <typeparam name="TResult">The public result type returned when the query is invoked.</typeparam>
 public interface IQuery<TResult>
 {
     /// <summary>
-    /// Gets the raw SQL query to execute.
+    /// Gets the original raw SQL text for the query, including every result set block.
     /// </summary>
     string RawSql { get; }
 
     /// <summary>
-    /// Gets the directives associated with the query.
+    /// Gets the global directives associated with the query.
     /// </summary>
     IReadOnlyList<string> Directives { get; }
 
     /// <summary>
-    /// Gets the expected result cardinality for the query.
+    /// Gets the SQL result sets that compose this query. Each result set contains its own SQL text,
+    /// directives, cardinality and result shape.
     /// </summary>
-    QueryCardinality Cardinality { get; }
+    IReadOnlyList<QueryResultSet> ResultSets { get; }
 
     /// <summary>
     /// Gets the public result type returned when the query is invoked.

--- a/src/Foundation/Persistence/Queries/IQueryExecutionContext.cs
+++ b/src/Foundation/Persistence/Queries/IQueryExecutionContext.cs
@@ -21,7 +21,12 @@ public interface IQueryExecutionContext
     public bool IsExecuted { get; }
 
     /// <summary>
-    /// A collection of directives associated with the query.
+    /// Indicates whether the query has more than one result set.
+    /// </summary>
+    public bool HasMultipleResultSets { get; }
+
+    /// <summary>
+    /// Gets the global directives associated with the query.
     /// </summary>
     /// <remarks>A directive is a comment in the SQL file that starts with "-- @".</remarks>
     public ICollection<string> Directives { get; }
@@ -38,15 +43,21 @@ public interface IQueryExecutionContext
     public CancellationToken CancellationToken { get; }
 
     /// <summary>
-    /// The raw SQL query as a text string sourced from the associated .sql file.
+    /// The original raw SQL text for the query execution, including every result set block when the query has multiple result sets.
     /// </summary>
-    /// <remarks>It can be modified from a query middleware.</remarks>
-    public string RawQuery { get; set; }
+    /// <remarks>Middlewares must modify the <see cref="IQueryResultSetExecutionContext.RawQuery"/> of the corresponding result set instead.</remarks>
+    public string RawQuery { get; }
 
     /// <summary>
-    /// Retrieves the collection of results obtained after executing the query.
+    /// Gets the result sets that compose the query execution.
     /// </summary>
-    /// <exception cref="System.InvalidOperationException">Thrown when the query is not executed yed.</exception>
+    /// <remarks>Queries with a single result set expose one implicit result set with a null name.</remarks>
+    public IReadOnlyList<IQueryResultSetExecutionContext> ResultSets { get; }
+
+    /// <summary>
+    /// Retrieves the collection of result set results obtained after executing the query.
+    /// </summary>
+    /// <exception cref="System.InvalidOperationException">Thrown when the query is not executed yet.</exception>
     public IReadOnlyList<object> Results { get; }
 
     /// <summary>

--- a/src/Foundation/Persistence/Queries/IQueryExecutor.cs
+++ b/src/Foundation/Persistence/Queries/IQueryExecutor.cs
@@ -27,6 +27,18 @@ public interface IQueryExecutor
     public Task<IReadOnlyCollection<TResult>> QueryAsync<TResult>(string query, object? parameters, IDbTransaction? dbTransaction = null, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Executes multiple SQL result sets in a single database call and returns one typed collection per result set.
+    /// </summary>
+    /// <param name="resultSets">The result sets to execute.</param>
+    /// <param name="parameters">The parameters to pass to the queries. Can be null if no parameters are required.</param>
+    /// <param name="dbTransaction">The transaction within which the queries should be executed. Can be null.</param>
+    /// <param name="cancellationToken">A token to cancel the query.</param>
+    /// <returns>
+    /// A task representing the asynchronous operation. Each item in the result is a typed <see cref="IReadOnlyCollection{T}"/>.
+    /// </returns>
+    public Task<IReadOnlyList<object>> QueryResultSetsAsync(IReadOnlyList<QueryResultSet> resultSets, IReadOnlyList<string> directives, object? parameters, IDbTransaction? dbTransaction = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Executes an asynchronous query and retrieves a single result of type TResult.
     /// </summary>
     /// <typeparam name="TResult">The type of the result object to retrieve. It only accepts DTO objects with writable properties.</typeparam>
@@ -80,7 +92,8 @@ public interface IQueryExecutor
     /// <returns>
     /// A task representing the asynchronous operation. The task result contains a single TResult object.
     /// </returns>
-    /// <exception cref="InvalidOperationException">Thrown if the query does not return exactly one result.</exception>
+    /// <exception cref="EmptyResultException">Thrown if the query returns no results.</exception>
+    /// <exception cref="NonUniqueResultException">Thrown if the query returns more than one result.</exception>
     public Task<TResult> QuerySingleAsync<TResult>(string query, IDbTransaction? dbTransaction = null, CancellationToken cancellationToken = default)
     {
         return QuerySingleAsync<TResult>(query, null, dbTransaction, cancellationToken);

--- a/src/Foundation/Persistence/Queries/IQueryResultSetExecutionContext.cs
+++ b/src/Foundation/Persistence/Queries/IQueryResultSetExecutionContext.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+
+namespace IOKode.OpinionatedFramework.Persistence.Queries;
+
+/// <summary>
+/// Represents the execution context for one SQL result set within a query execution.
+/// </summary>
+public interface IQueryResultSetExecutionContext
+{
+    /// <summary>
+    /// The result set name. Null for implicit single-result-set queries.
+    /// </summary>
+    public string? Name { get; }
+
+    /// <summary>
+    /// The directives associated with this result set.
+    /// </summary>
+    public IReadOnlyList<string> Directives { get; }
+
+    /// <summary>
+    /// The expected number of rows returned by this result set.
+    /// </summary>
+    public QueryCardinality Cardinality { get; }
+
+    /// <summary>
+    /// The shape of each row returned by this result set.
+    /// </summary>
+    public QueryResultShape Shape { get; }
+
+    /// <summary>
+    /// The CLR type of each row or scalar value returned by this result set.
+    /// </summary>
+    public Type ResultType { get; }
+
+    /// <summary>
+    /// The SQL column name for scalar result sets.
+    /// </summary>
+    public string? ScalarColumnName { get; }
+
+    /// <summary>
+    /// The raw SQL query for this result set.
+    /// </summary>
+    /// <remarks>It can be modified from a query middleware.</remarks>
+    public string RawQuery { get; set; }
+
+    /// <summary>
+    /// Retrieves the collection of results obtained after executing this result set.
+    /// </summary>
+    public IReadOnlyList<object> Results { get; }
+}

--- a/src/Foundation/Persistence/Queries/QueryDefinitionException.cs
+++ b/src/Foundation/Persistence/Queries/QueryDefinitionException.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace IOKode.OpinionatedFramework.Persistence.Queries;
+
+/// <summary>
+/// Represents an error in the way a query is defined.
+/// </summary>
+public class QueryDefinitionException(string message) : Exception(message);

--- a/src/Foundation/Persistence/Queries/QueryExecutorExtensions.cs
+++ b/src/Foundation/Persistence/Queries/QueryExecutorExtensions.cs
@@ -31,73 +31,43 @@ public static class QueryExecutorExtensions
     {
         var queryType = query.GetType();
         var mapParametersMethod = queryType.GetMethod("MapParameters", BindingFlags.Instance | BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException($"Query type '{queryType.FullName}' does not declare MapParameters.");
+            ?? throw new QueryDefinitionException($"Query type '{queryType.FullName}' does not declare MapParameters.");
         var mapResultMethod = queryType.GetMethod("MapResult", BindingFlags.Instance | BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException($"Query type '{queryType.FullName}' does not declare MapResult.");
-        var rowType = GetRowType(mapResultMethod, queryType);
+            ?? throw new QueryDefinitionException($"Query type '{queryType.FullName}' does not declare MapResult.");
         var parameters = mapParametersMethod.Invoke(query, Array.Empty<object?>());
-        var cardinality = query.Cardinality;
-        var invokeTypedMethod = typeof(QueryExecutorExtensions)
-            .GetMethod(nameof(InvokeTypedAsync), BindingFlags.Static | BindingFlags.NonPublic)!
-            .MakeGenericMethod(typeof(TResult), rowType);
-        var resultTask = (Task<TResult>) invokeTypedMethod.Invoke(null,
-            new object?[] { queryExecutor, query, parameters, mapResultMethod, cardinality, cancellationToken })!;
+        var rawResultSets = await queryExecutor.QueryResultSetsAsync(query.ResultSets, query.Directives, parameters, null, cancellationToken);
+        var mapResultArgument = GetMapResultArgument(mapResultMethod, queryType, rawResultSets);
 
-        return await resultTask;
+        return (TResult) mapResultMethod.Invoke(query, new[] { mapResultArgument })!;
     }
 
     /// <summary>
     /// Gets the raw row type from the generated <c>MapResult</c> method signature.
     /// </summary>
-    private static Type GetRowType(MethodInfo mapResultMethod, Type queryType)
+    private static object GetMapResultArgument(MethodInfo mapResultMethod, Type queryType, IReadOnlyList<object> rawResultSets)
     {
         var parameters = mapResultMethod.GetParameters();
         if (parameters.Length != 1)
         {
-            throw new InvalidOperationException($"Query type '{queryType.FullName}' must declare MapResult with a single parameter.");
+            throw new QueryDefinitionException($"Query type '{queryType.FullName}' must declare MapResult with a single parameter.");
         }
 
         var rawResultsType = parameters[0].ParameterType;
-        if (!rawResultsType.IsGenericType || rawResultsType.GetGenericTypeDefinition() != typeof(IReadOnlyCollection<>))
+        if (rawResultsType == typeof(IReadOnlyList<object>))
         {
-            throw new InvalidOperationException($"Query type '{queryType.FullName}' must declare MapResult with an IReadOnlyCollection<T> parameter.");
+            return rawResultSets;
         }
 
-        return rawResultsType.GetGenericArguments()[0];
-    }
-
-    /// <summary>
-    /// Executes the raw SQL with a statically known row type and maps the raw rows to the public result type.
-    /// </summary>
-    private static async Task<TResult> InvokeTypedAsync<TResult, TRow>(
-        IQueryExecutor queryExecutor,
-        IQuery<TResult> query,
-        object? parameters,
-        MethodInfo mapResultMethod,
-        QueryCardinality cardinality,
-        CancellationToken cancellationToken)
-    {
-        IReadOnlyCollection<TRow> rawResults = cardinality switch
+        if (rawResultsType.IsGenericType && rawResultsType.GetGenericTypeDefinition() == typeof(IReadOnlyCollection<>))
         {
-            QueryCardinality.ZeroOrMore => await queryExecutor.QueryAsync<TRow>(query.RawSql, parameters, null, cancellationToken),
-            QueryCardinality.One => new[] { await queryExecutor.QuerySingleAsync<TRow>(query.RawSql, parameters, null, cancellationToken) },
-            QueryCardinality.ZeroOrOne => await QuerySingleOrDefaultAsCollectionAsync<TRow>(queryExecutor, query.RawSql, parameters, cancellationToken),
-            _ => throw new ArgumentOutOfRangeException(nameof(cardinality))
-        };
+            if (rawResultSets.Count != 1)
+            {
+                throw new QueryDefinitionException($"Query type '{queryType.FullName}' must declare MapResult with IReadOnlyList<object> for multiple result sets.");
+            }
 
-        return (TResult) mapResultMethod.Invoke(query, new object?[] { rawResults })!;
-    }
+            return rawResultSets[0];
+        }
 
-    /// <summary>
-    /// Executes a single-or-default query and normalizes the optional row into a collection for <c>MapResult</c>.
-    /// </summary>
-    private static async Task<IReadOnlyCollection<TRow>> QuerySingleOrDefaultAsCollectionAsync<TRow>(
-        IQueryExecutor queryExecutor,
-        string rawSql,
-        object? parameters,
-        CancellationToken cancellationToken)
-    {
-        var rawResult = await queryExecutor.QuerySingleOrDefaultAsync<TRow>(rawSql, parameters, null, cancellationToken);
-        return rawResult is null ? Array.Empty<TRow>() : new[] { rawResult };
+        throw new QueryDefinitionException($"Query type '{queryType.FullName}' must declare MapResult with an IReadOnlyCollection<T> or IReadOnlyList<object> parameter.");
     }
 }

--- a/src/Foundation/Persistence/Queries/QueryResultSet.cs
+++ b/src/Foundation/Persistence/Queries/QueryResultSet.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+namespace IOKode.OpinionatedFramework.Persistence.Queries;
+
+/// <summary>
+/// Describes a SQL result set that must be executed and mapped by a query executor.
+/// </summary>
+public sealed class QueryResultSet
+{
+    /// <summary>
+    /// The result set name. Null for implicit single-result-set queries.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// The SQL text for this result set.
+    /// </summary>
+    public required string RawSql { get; init; }
+
+    /// <summary>
+    /// The directives associated with this result set.
+    /// </summary>
+    public required IReadOnlyList<string> Directives { get; init; }
+
+    /// <summary>
+    /// The expected number of rows returned by this result set.
+    /// </summary>
+    public required QueryCardinality Cardinality { get; init; }
+
+    /// <summary>
+    /// The shape of each row returned by this result set.
+    /// </summary>
+    public required QueryResultShape Shape { get; init; }
+
+    /// <summary>
+    /// The CLR type of each row or scalar value returned by this result set.
+    /// </summary>
+    public required Type ResultType { get; init; }
+
+    /// <summary>
+    /// The SQL column name for scalar result sets.
+    /// </summary>
+    public string? ScalarColumnName { get; init; }
+}

--- a/src/Foundation/Persistence/Queries/QueryResultShape.cs
+++ b/src/Foundation/Persistence/Queries/QueryResultShape.cs
@@ -1,0 +1,17 @@
+namespace IOKode.OpinionatedFramework.Persistence.Queries;
+
+/// <summary>
+/// Defines the shape of each row returned by a query result set.
+/// </summary>
+public enum QueryResultShape
+{
+    /// <summary>
+    /// Each row is mapped to an object with writable properties.
+    /// </summary>
+    Object,
+
+    /// <summary>
+    /// Each row is mapped to a single scalar value.
+    /// </summary>
+    Scalar
+}

--- a/src/Foundation/Persistence/Queries/QueryResultsWithCount.cs
+++ b/src/Foundation/Persistence/Queries/QueryResultsWithCount.cs
@@ -1,9 +1,0 @@
-using System.Collections.Generic;
-
-namespace IOKode.OpinionatedFramework.Persistence.Queries;
-
-public class QueryResultsWithCount<TResult>
-{
-    public required IReadOnlyCollection<TResult> Results { get; init; }
-    public required int Count { get; init; }
-}

--- a/src/Foundation/Persistence/Queries/SqlQueryBlocks.cs
+++ b/src/Foundation/Persistence/Queries/SqlQueryBlocks.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace IOKode.OpinionatedFramework.Persistence.Queries;
+
+/// <summary>
+/// Represents the global SQL block and result set SQL blocks of a query.
+/// </summary>
+public class SqlQueryBlocks
+{
+    /// <summary>
+    /// Gets the SQL text that appears before the first explicit result set block.
+    /// </summary>
+    public required string GlobalRawSql { get; init; }
+
+    /// <summary>
+    /// Gets the directives that appear before the first explicit result set block.
+    /// </summary>
+    public required IReadOnlyList<string> GlobalDirectives { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the query declares explicit result set blocks.
+    /// </summary>
+    public required bool HasExplicitResultSets { get; init; }
+
+    /// <summary>
+    /// Gets the result set blocks of the query.
+    /// </summary>
+    public required IReadOnlyList<SqlQueryResultSetBlock> ResultSets { get; init; }
+}

--- a/src/Foundation/Persistence/Queries/SqlQueryResultSetBlock.cs
+++ b/src/Foundation/Persistence/Queries/SqlQueryResultSetBlock.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace IOKode.OpinionatedFramework.Persistence.Queries;
+
+/// <summary>
+/// Represents the SQL text and directives for a query result set block.
+/// </summary>
+public class SqlQueryResultSetBlock
+{
+    /// <summary>
+    /// Gets the SQL text that belongs to this result set block.
+    /// </summary>
+    public required string RawSql { get; init; }
+
+    /// <summary>
+    /// Gets the directives that belong to this result set block.
+    /// </summary>
+    public required IReadOnlyList<string> Directives { get; init; }
+}

--- a/src/Foundation/Utilities/SqlUtilities.cs
+++ b/src/Foundation/Utilities/SqlUtilities.cs
@@ -11,11 +11,14 @@ namespace IOKode.OpinionatedFramework.Utilities;
 /// </summary>
 public static partial class SqlUtilities
 {
+    private static readonly Regex directivePrefixRegex = new(@"--[ \t]*@", RegexOptions.Compiled);
+    
     private static readonly IReadOnlyDictionary<string, QueryCardinality> cardinalityDirectives =
         new Dictionary<string, QueryCardinality>(StringComparer.OrdinalIgnoreCase)
         {
-            ["single"] = QueryCardinality.One,
-            ["single_or_default"] = QueryCardinality.ZeroOrOne,
+            ["zero_or_more"] = QueryCardinality.ZeroOrMore,
+            ["one"] = QueryCardinality.One,
+            ["zero_or_one"] = QueryCardinality.ZeroOrOne,
         };
 
     /// <summary>
@@ -27,7 +30,6 @@ public static partial class SqlUtilities
     {
         var directives = new List<string>();
         var lines = rawSql.Split('\n');
-        var directivePrefixRegex = GetDirectivePrefixRegex();
 
         foreach (var line in lines)
         {
@@ -46,33 +48,110 @@ public static partial class SqlUtilities
     }
 
     /// <summary>
+    /// Splits raw SQL text into global directives and result set blocks.
+    /// </summary>
+    /// <remarks>
+    /// When explicit result sets are declared, global directives are the directives that appear before the first
+    /// <c>@result_set</c> directive. Result set directives are the directives that appear within each result set block.
+    /// When no explicit result set is declared, all directives are global and also belong to the implicit result set.
+    /// </remarks>
+    /// <param name="rawSql">The raw SQL text.</param>
+    /// <returns>The global SQL block and result set SQL blocks.</returns>
+    public static SqlQueryBlocks GetQueryBlocks(string rawSql)
+    {
+        var lines = rawSql.Replace("\r\n", "\n").Split('\n');
+        var resultSetLineIndexes = lines
+            .Select((line, index) => new { line, index })
+            .Where(item => IsResultSetDirectiveLine(item.line))
+            .Select(item => item.index)
+            .ToArray();
+
+        if (resultSetLineIndexes.Length == 0)
+        {
+            return new SqlQueryBlocks
+            {
+                GlobalRawSql = rawSql,
+                GlobalDirectives = GetDirectives(rawSql),
+                HasExplicitResultSets = false,
+                ResultSets = new[]
+                {
+                    new SqlQueryResultSetBlock
+                    {
+                        RawSql = rawSql,
+                        Directives = GetDirectives(rawSql)
+                    }
+                }
+            };
+        }
+
+        var globalRawSql = string.Join("\n", lines.Take(resultSetLineIndexes[0]));
+        var resultSets = resultSetLineIndexes
+            .Select((lineIndex, index) =>
+            {
+                var nextLineIndex = index + 1 < resultSetLineIndexes.Length ? resultSetLineIndexes[index + 1] : lines.Length;
+                var block = string.Join("\n", lines.Skip(lineIndex).Take(nextLineIndex - lineIndex));
+                return new SqlQueryResultSetBlock
+                {
+                    RawSql = block,
+                    Directives = GetDirectives(block)
+                };
+            })
+            .ToArray();
+
+        return new SqlQueryBlocks
+        {
+            GlobalRawSql = globalRawSql,
+            GlobalDirectives = GetDirectives(globalRawSql),
+            HasExplicitResultSets = true,
+            ResultSets = resultSets
+        };
+    }
+
+    /// <summary>
     /// Gets the query cardinality represented by the provided directives.
     /// </summary>
     /// <param name="directives">The directives associated with a query.</param>
     /// <returns>The cardinality represented by the directives, or <see cref="QueryCardinality.ZeroOrMore"/> when no cardinality directive is present.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when the provided directives contain incompatible cardinalities.</exception>
+    /// <exception cref="QueryDefinitionException">Thrown when the provided directives contain incompatible cardinalities.</exception>
     public static QueryCardinality GetCardinality(IReadOnlyList<string> directives)
     {
         var cardinalities = directives
-            .Select(GetDirectiveName)
-            .Where(directiveName => directiveName != null && cardinalityDirectives.ContainsKey(directiveName))
-            .Select(directiveName => cardinalityDirectives[directiveName!])
+            .Select(GetCardinalityDirectiveValue)
+            .Where(cardinalityValue => cardinalityValue != null && cardinalityDirectives.ContainsKey(cardinalityValue))
+            .Select(cardinalityValue => cardinalityDirectives[cardinalityValue!])
             .Distinct()
             .ToArray();
 
         if (cardinalities.Length > 1)
         {
-            throw new InvalidOperationException($"Incompatible query cardinality directives: {string.Join(", ", cardinalities)}.");
+            throw new QueryDefinitionException($"Incompatible query cardinality directives: {string.Join(", ", cardinalities)}.");
         }
 
-        return cardinalities.FirstOrDefault(QueryCardinality.ZeroOrMore);
+        return cardinalities.Length == 0 ? QueryCardinality.ZeroOrMore : cardinalities[0];
     }
 
-    private static string? GetDirectiveName(string directive)
+    private static string? GetCardinalityDirectiveValue(string directive)
     {
-        return directive.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+        var directiveParts = directive.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+        if (directiveParts.Length != 2 || !directiveParts[0].Equals("cardinality", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return directiveParts[1];
     }
 
-    [GeneratedRegex(@"--[ \t]*@")]
-    private static partial Regex GetDirectivePrefixRegex();
+    private static bool IsResultSetDirectiveLine(string line)
+    {
+        var trimmedLine = line.Trim();
+        var match = directivePrefixRegex.Match(trimmedLine);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        var directive = trimmedLine[match.Length..].Trim();
+        var directiveName = directive.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+        return directiveName == "result_set";
+    }
 }

--- a/src/MSBuild/Base.props
+++ b/src/MSBuild/Base.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup Label="Build settings">
         <TargetFramework>net10.0</TargetFramework>
-        <Version>0.37.2-dev</Version>
+        <Version>0.38.0-dev</Version>
         <EnsuringVersion>1.2.2</EnsuringVersion>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/SourceGenerators.SqlQueryObjects/QueryObjectsGenerator.CodeGeneraton.cs
+++ b/src/SourceGenerators.SqlQueryObjects/QueryObjectsGenerator.CodeGeneraton.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Humanizer;
+using IOKode.OpinionatedFramework.Persistence.Queries;
+using IOKode.OpinionatedFramework.Utilities;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -10,6 +13,12 @@ namespace IOKode.OpinionatedFramework.SourceGenerators.SqlQueryObjects;
 
 public partial class QueryObjectsGenerator
 {
+    private enum ResultSetShape
+    {
+        Object,
+        Scalar
+    }
+
     private class ConfigOptions
     {
         public required string RootNamespace { get; set; }
@@ -26,27 +35,23 @@ public partial class QueryObjectsGenerator
     {
         public SqlFile SqlFile { get; }
         public ConfigOptions ConfigOptions { get; }
-        
-        public bool IsSingleResult { get; private set; }
-        public bool IsSingleOrDefaultResult { get; private set; }
+
         public bool HasMapDirective { get; private set; }
         public bool IsInternal { get; private set; }
-        public bool HasCount { get; private set; }
+        public bool HasExplicitResultSets { get; private set; }
 
         public string[] Usings { get; private set; }
+        public string[] GlobalDirectives { get; private set; }
         public ParameterType[] QueryParameters { get; private set; }
         public ParameterType[] InputParameters { get; private set; }
-        public ParameterType[] ResultParameters { get; private set;}
         public string[] Attributes { get; private set; }
-        public string CountName { get; private set; } = "count";
-        public string? QueryResultName { get; private set; }
-        public string PascalCountName => CountName.Pascalize();
+        public ResultSetDefinition[] ResultSets { get; private set; }
 
         public string? MappedQueryResultString { get; set; }
         public bool HasMappedParameters { get; private set; }
         public bool HasMappedResult => !string.IsNullOrWhiteSpace(MappedQueryResultString);
         public bool RequiresCustomMapParameters => HasMapDirective && HasMappedParameters;
-        public bool RequiresCustomMapResult => HasMapDirective && (!HasMappedParameters || HasMappedResult);
+        public bool RequiresCustomMapResult => !HasExplicitResultSets && HasMapDirective && (!HasMappedParameters || HasMappedResult);
 
         public string Name => Path.GetFileNameWithoutExtension(SqlFile.FilePath);
         public string ClassName => Name.EndsWith("Query") ? Name : $"{Name}Query";
@@ -54,7 +59,9 @@ public partial class QueryObjectsGenerator
 
         public string Namespace => _GetNamespace();
         public string QueryContent => SqlFile.Content;
-        
+        public ResultSetDefinition SingleResultSet => ResultSets[0];
+        public string CompositeQueryResultClassName => $"{ClassName}Result";
+
         public string QueryParametersString
         {
             get
@@ -70,64 +77,42 @@ public partial class QueryObjectsGenerator
             }
         }
 
-        public string QueryResultString => IsSingleResult
-            ? QueryResultClassName
-            : IsSingleOrDefaultResult
-                ? $"{QueryResultClassName}?"
-                : HasCount
-                    ? $"QueryResultsWithCount<{QueryResultClassName}>"
-                    : $"IReadOnlyCollection<{QueryResultClassName}>";
-        
-        public string InvokeResultString => HasMapDirective && !string.IsNullOrWhiteSpace(MappedQueryResultString)
+        public string QueryResultString => HasExplicitResultSets
+            ? CompositeQueryResultClassName
+            : SingleResultSet.ResultString;
+
+        public string InvokeResultString => RequiresCustomMapResult && !string.IsNullOrWhiteSpace(MappedQueryResultString)
             ? MappedQueryResultString!
             : QueryResultString;
 
-        public string QueryRowResultString => HasCount ? $"{QueryResultClassName}WithCount" : QueryResultClassName;
+        public string QueryClassAccessor => IsInternal ? "internal" : "public";
         public string QueryParametersClassName => $"{ClassName}Parameters";
 
-        public string QueryClassAccessor => IsInternal ? "internal" : "public"; 
-        public string QueryResultClassName => QueryResultName ?? $"{ClassName}Result";
         private readonly string _QueryParameterRegex = @"--\s*@parameter[ \t]([^\n]+)[ \t]+(\S+)";
-        private readonly string _QueryResultParameterRegex = @"--\s*@result[ \t]([^\n]+)[ \t]+(\S+)";
         private readonly string _QueryNamespaceParameterRegex = @"--\s*@namespace[ \t]+(\S+)";
         private readonly string _QueryUsingRegex = @"--\s*@using[ \t]+([^\n]+)";
-        private readonly string _QueryIsSingleResultRegex = @"--\s*@single(?!\w)";
-        private readonly string _QueryIsSingleOrDefaultResultRegex = @"--\s*@single_or_default";
         private readonly string _QueryAttributeRegex = @"--\s*@attribute[ \t]([^\n]+)\s*";
         private readonly string _QueryInternalRegex = @"--\s*@internal";
         private readonly string _QueryMapRegex = @"--\s*@map(?:[ \t]+([^\n]*?))?(?:[ \t]*->[ \t]*([^\n]+))?\s*$";
-        private readonly string _QueryCountRegex = @"--\s*@count(?:[ \t]+(\S+))?";
-        private readonly string _QueryResultNameRegex = @"--\s*@query_result_name[ \t]+([\S]+)";
 
         public QueryObjectClass(SqlFile sqlFile, ConfigOptions configOptions)
         {
             SqlFile = sqlFile;
             ConfigOptions = configOptions;
 
-            IsSingleResult = Regex.IsMatch(sqlFile.Content, _QueryIsSingleResultRegex);
-            IsSingleOrDefaultResult = Regex.IsMatch(sqlFile.Content, _QueryIsSingleOrDefaultResultRegex);
             HasMapDirective = Regex.IsMatch(sqlFile.Content, _QueryMapRegex, RegexOptions.Multiline);
             IsInternal = Regex.IsMatch(sqlFile.Content, _QueryInternalRegex);
 
             var queryUsingMatches = Regex.Matches(sqlFile.Content, _QueryUsingRegex);
             var queryParameterMatches = Regex.Matches(sqlFile.Content, _QueryParameterRegex);
-            var queryResultParameterMatches = Regex.Matches(sqlFile.Content, _QueryResultParameterRegex);
             var queryAttributeMatches = Regex.Matches(sqlFile.Content, _QueryAttributeRegex);
             var queryMapMatches = Regex.Matches(sqlFile.Content, _QueryMapRegex, RegexOptions.Multiline);
-            var queryCountMatch = Regex.Match(sqlFile.Content, _QueryCountRegex);
-            var queryResultNameMatch = Regex.Match(sqlFile.Content, _QueryResultNameRegex);
 
             Usings = queryUsingMatches.Cast<Match>().Select(match => match.Groups[1].Value).ToArray();
-            QueryParameters = queryParameterMatches
-                .Cast<Match>()
-                .Select(match => new ParameterType
-                {
-                    Type = SyntaxFactory.ParseTypeName(match.Groups[1].Value).ToString(),
-                    Name = SyntaxFactory.ParseName(match.Groups[2].Value).ToString(),
-                })
+            GlobalDirectives = SqlUtilities.GetQueryBlocks(sqlFile.Content).GlobalDirectives
+                .Select(EscapeStringLiteralContent)
                 .ToArray();
-
-            ResultParameters = queryResultParameterMatches
+            QueryParameters = queryParameterMatches
                 .Cast<Match>()
                 .Select(match => new ParameterType
                 {
@@ -157,13 +142,21 @@ public partial class QueryObjectsGenerator
                 .Cast<string>()
                 .ToArray();
 
-            HasCount = queryCountMatch.Success;
-            var countName = queryCountMatch.Groups[1].Value;
-            if (HasCount && !string.IsNullOrWhiteSpace(countName))
+            ResultSets = ParseResultSets(sqlFile.Content);
+        }
+
+        private ResultSetDefinition[] ParseResultSets(string content)
+        {
+            var queryBlocks = SqlUtilities.GetQueryBlocks(content);
+            HasExplicitResultSets = queryBlocks.HasExplicitResultSets;
+            if (!HasExplicitResultSets)
             {
-                CountName = countName;
+                return new[] { ResultSetDefinition.ParseImplicit(queryBlocks.ResultSets[0], $"{ClassName}Result") };
             }
-            QueryResultName = queryResultNameMatch.Success ? queryResultNameMatch.Groups[1].Value : null;
+
+            return queryBlocks.ResultSets
+                .Select((block, index) => ResultSetDefinition.ParseExplicit(block, index))
+                .ToArray();
         }
 
         private string _GetNamespace()
@@ -203,6 +196,112 @@ public partial class QueryObjectsGenerator
                 })
                 .ToArray();
         }
+
+    }
+
+    private class ResultSetDefinition
+    {
+        public required string? Name { get; init; }
+        public required int Index { get; init; }
+        public required string RawSql { get; init; }
+        public required string[] Directives { get; init; }
+        public required QueryCardinality Cardinality { get; init; }
+        public required ResultSetShape Shape { get; init; }
+        public required ParameterType[] ResultParameters { get; init; }
+        public required ParameterType? ScalarResult { get; init; }
+        public required string ObjectResultClassName { get; init; }
+
+        public bool IsScalar => Shape == ResultSetShape.Scalar;
+        public string PropertyName => Name!.Pascalize();
+        public string NameLiteral => Name == null ? "null" : $"\"{Name}\"";
+        public string CardinalityString => $"QueryCardinality.{Cardinality}";
+        public string ShapeString => $"QueryResultShape.{Shape}";
+        public string ElementType => IsScalar ? ScalarResult!.Type : ObjectResultClassName;
+        public string ElementTypeForTypeOf => IsScalar ? ScalarResult!.TypeForTypeOf : ObjectResultClassName;
+        public string ScalarColumnName => ScalarResult?.Name ?? string.Empty;
+        public string ResultString => Cardinality switch
+        {
+            QueryCardinality.One => ElementType,
+            QueryCardinality.ZeroOrOne => $"{ElementType}?",
+            _ => $"IReadOnlyCollection<{ElementType}>"
+        };
+
+        public static ResultSetDefinition ParseImplicit(SqlQueryResultSetBlock block, string objectResultClassName)
+        {
+            return Parse(block, null, 0, objectResultClassName);
+        }
+
+        public static ResultSetDefinition ParseExplicit(SqlQueryResultSetBlock block, int index)
+        {
+            var resultSetMatch = Regex.Match(block.RawSql, @"--\s*@result_set[ \t]+(\S+)");
+            if (!resultSetMatch.Success)
+            {
+                throw new QueryDefinitionException("Explicit result sets must declare a name.");
+            }
+
+            var resultSetName = resultSetMatch.Groups[1].Value;
+            var objectResultClassName = $"{resultSetName.Singularize().Pascalize()}Result";
+            return Parse(block, resultSetName, index, objectResultClassName);
+        }
+
+        private static ResultSetDefinition Parse(SqlQueryResultSetBlock block, string? name, int index, string objectResultClassName)
+        {
+            var resultMatches = Regex.Matches(block.RawSql, @"--\s*@result[ \t]([^\n]+)[ \t]+(\S+)");
+            var scalarResultMatches = Regex.Matches(block.RawSql, @"--\s*@scalar_result[ \t]([^\n]+)[ \t]+(\S+)");
+
+            if (resultMatches.Count > 0 && scalarResultMatches.Count > 0)
+            {
+                throw new QueryDefinitionException("A result set cannot declare both @result and @scalar_result.");
+            }
+
+            if (scalarResultMatches.Count > 1)
+            {
+                throw new QueryDefinitionException("A result set cannot declare more than one @scalar_result.");
+            }
+
+            if (resultMatches.Count == 0 && scalarResultMatches.Count == 0)
+            {
+                throw new QueryDefinitionException("A result set must declare @result or @scalar_result.");
+            }
+
+            var cardinality = ParseCardinality(block);
+            var resultParameters = resultMatches
+                .Cast<Match>()
+                .Select(match => new ParameterType
+                {
+                    Type = SyntaxFactory.ParseTypeName(match.Groups[1].Value).ToString(),
+                    Name = SyntaxFactory.ParseName(match.Groups[2].Value).ToString(),
+                })
+                .ToArray();
+            var scalarResult = scalarResultMatches
+                .Cast<Match>()
+                .Select(match => new ParameterType
+                {
+                    Type = SyntaxFactory.ParseTypeName(match.Groups[1].Value).ToString(),
+                    Name = SyntaxFactory.ParseName(match.Groups[2].Value).ToString(),
+                })
+                .FirstOrDefault();
+
+            return new ResultSetDefinition
+            {
+                Name = name,
+                Index = index,
+                RawSql = block.RawSql,
+                Directives = block.Directives
+                    .Select(EscapeStringLiteralContent)
+                    .ToArray(),
+                Cardinality = cardinality,
+                Shape = scalarResult != null ? ResultSetShape.Scalar : ResultSetShape.Object,
+                ResultParameters = resultParameters,
+                ScalarResult = scalarResult,
+                ObjectResultClassName = objectResultClassName,
+            };
+        }
+
+        private static QueryCardinality ParseCardinality(SqlQueryResultSetBlock block)
+        {
+            return SqlUtilities.GetCardinality(block.Directives);
+        }
     }
 
     private class ParameterType
@@ -212,6 +311,12 @@ public partial class QueryObjectsGenerator
         public string PascalCaseName => Name.Pascalize();
         public string CamelCaseName => Name.Camelize();
         public string RequiredKeyword => Type.EndsWith("?") ? string.Empty : "required ";
+        public string TypeForTypeOf => Type.EndsWith("?") ? Type[..^1] : Type;
+    }
+
+    private static string EscapeStringLiteralContent(string value)
+    {
+        return value.Replace("\\", "\\\\").Replace("\"", "\\\"");
     }
 
     private const string _QueryObjectClassTemplate =
@@ -226,7 +331,6 @@ public partial class QueryObjectsGenerator
         using System.Threading.Tasks;
         using IOKode.OpinionatedFramework;
         using IOKode.OpinionatedFramework.Persistence.Queries;
-        using IOKode.OpinionatedFramework.Utilities;
         {{~ for using in Usings ~}}
         using {{ using }};
         {{~ end ~}}
@@ -243,14 +347,41 @@ public partial class QueryObjectsGenerator
                 {{ QueryContent }}
                 """;
 
-            private static readonly IReadOnlyList<string> directives = SqlUtilities.GetDirectives(Query);
-            private static readonly QueryCardinality cardinality = SqlUtilities.GetCardinality(directives);
+            private static readonly IReadOnlyList<string> directives =
+            [
+                {{~ for directive in GlobalDirectives ~}}
+                "{{ directive }}",
+                {{~ end ~}}
+            ];
+            private static readonly IReadOnlyList<QueryResultSet> resultSets =
+            [
+                {{~ for result_set in ResultSets ~}}
+                new QueryResultSet
+                {
+                    Name = {{ result_set.NameLiteral }},
+                    RawSql =
+                        """
+                        {{ result_set.RawSql }}
+                        """,
+                    Directives =
+                    [
+                        {{~ for directive in result_set.Directives ~}}
+                        "{{ directive }}",
+                        {{~ end ~}}
+                    ],
+                    Cardinality = {{ result_set.CardinalityString }},
+                    Shape = {{ result_set.ShapeString }},
+                    ResultType = typeof({{ result_set.ElementTypeForTypeOf }}),
+                    ScalarColumnName = {{ if result_set.IsScalar }}"{{ result_set.ScalarColumnName }}"{{ else }}null{{ end }}
+                },
+                {{~ end ~}}
+            ];
 
             public string RawSql => Query;
 
             public IReadOnlyList<string> Directives => directives;
 
-            public QueryCardinality Cardinality => cardinality;
+            public IReadOnlyList<QueryResultSet> ResultSets => resultSets;
 
             {{~ for parameter in InputParameters ~}}
             public {{ parameter.RequiredKeyword }}{{ parameter.Type }} {{ parameter.PascalCaseName }} { get; init; }
@@ -270,56 +401,65 @@ public partial class QueryObjectsGenerator
             }
             {{~ end ~}}
 
-            {{~ if RequiresCustomMapResult ~}}
-            private partial {{ InvokeResultString }} MapResult(IReadOnlyCollection<{{ QueryRowResultString }}> rawResults);
-            {{~ else ~}}
-            private {{ InvokeResultString }} MapResult(IReadOnlyCollection<{{ QueryRowResultString }}> rawResults)
+            {{~ if HasExplicitResultSets ~}}
+            private {{ InvokeResultString }} MapResult(IReadOnlyList<object> rawResultSets)
             {
-                {{~ if IsSingleResult ~}}
-                return rawResults.First();
-                {{~ else if IsSingleOrDefaultResult ~}}
-                return rawResults.FirstOrDefault();
-                {{~ else if HasCount ~}}
-                var queryResult = new {{ QueryResultString }}
+                return new {{ InvokeResultString }}
                 {
-                    Results = rawResults.Select(result => MapResultWithCount(result)).ToList(),
-                    Count = rawResults.FirstOrDefault()?.{{ PascalCountName }} ?? 0
-                };
-                return queryResult;
-                {{~ else ~}}
-                return rawResults;
-                {{~ end ~}}
-            }
-            {{~ end ~}}
-            
-            {{~ if HasCount ~}}
-            private static {{ QueryResultClassName }} MapResultWithCount({{ QueryResultClassName }}WithCount resultWithCount)
-            { 
-                return new {{ QueryResultClassName }}
-                {
-                    {{~ for parameter in ResultParameters ~}}
-                    {{ parameter.PascalCaseName }} = resultWithCount.{{ parameter.PascalCaseName }},
+                    {{~ for result_set in ResultSets ~}}
+                    {{ result_set.PropertyName }} = Map{{ result_set.Cardinality }}(GetResultSet<{{ result_set.ElementType }}>(rawResultSets, {{ result_set.Index }})),
                     {{~ end ~}}
                 };
             }
+            {{~ else if RequiresCustomMapResult ~}}
+            private partial {{ InvokeResultString }} MapResult(IReadOnlyCollection<{{ SingleResultSet.ElementType }}> rawResults);
+            {{~ else ~}}
+            private {{ InvokeResultString }} MapResult(IReadOnlyCollection<{{ SingleResultSet.ElementType }}> rawResults)
+            {
+                return Map{{ SingleResultSet.Cardinality }}(rawResults);
+            }
             {{~ end ~}}
+
+            private static IReadOnlyCollection<T> GetResultSet<T>(IReadOnlyList<object> rawResultSets, int index)
+            {
+                return (IReadOnlyCollection<T>)rawResultSets[index];
+            }
+
+            private static IReadOnlyCollection<T> MapZeroOrMore<T>(IReadOnlyCollection<T> rawResults)
+            {
+                return rawResults;
+            }
+
+            private static T MapOne<T>(IReadOnlyCollection<T> rawResults)
+            {
+                return rawResults.First();
+            }
+
+            private static T? MapZeroOrOne<T>(IReadOnlyCollection<T> rawResults)
+            {
+                return rawResults.FirstOrDefault();
+            }
+
         }
 
-        {{ QueryClassAccessor }} partial record {{ QueryResultClassName }}
+        {{~ if HasExplicitResultSets ~}}
+        {{ QueryClassAccessor }} partial record {{ CompositeQueryResultClassName }}
         {
-            {{~ for parameter in ResultParameters ~}}
+            {{~ for result_set in ResultSets ~}}
+            public required {{ result_set.ResultString }} {{ result_set.PropertyName }} { get; init; }
+            {{~ end ~}}
+        }
+        {{~ end ~}}
+
+        {{~ for result_set in ResultSets ~}}
+        {{~ if !result_set.IsScalar ~}}
+        {{ QueryClassAccessor }} partial record {{ result_set.ObjectResultClassName }}
+        {
+            {{~ for parameter in result_set.ResultParameters ~}}
             public required {{ parameter.Type }} {{ parameter.PascalCaseName }} { get; init; }
             {{~ end ~}}
         }
-
-        {{~ if HasCount ~}}
-        {{ QueryClassAccessor }} partial record {{ QueryResultClassName }}WithCount
-        {
-            {{~ for parameter in ResultParameters ~}}
-            public required {{ parameter.Type }} {{ parameter.PascalCaseName }} { get; init; }
-            {{~ end ~}}
-            public required int {{ PascalCountName }} { get; init; }
-        }
+        {{~ end ~}}
         {{~ end ~}}
         
         {{ QueryClassAccessor }} partial record {{ QueryParametersClassName }}

--- a/src/SourceGenerators.SqlQueryObjects/SourceGenerators.SqlQueryObjects.csproj
+++ b/src/SourceGenerators.SqlQueryObjects/SourceGenerators.SqlQueryObjects.csproj
@@ -5,4 +5,11 @@
     <ItemGroup>
       <PackageReference Update="Scriban" PrivateAssets="all" IncludeAssets="build" />
     </ItemGroup>
+    <ItemGroup>
+      <Compile Include="..\Foundation\Persistence\Queries\QueryDefinitionException.cs" Link="Persistence\Queries\QueryDefinitionException.cs" />
+      <Compile Include="..\Foundation\Persistence\Queries\QueryCardinality.cs" Link="Persistence\Queries\QueryCardinality.cs" />
+      <Compile Include="..\Foundation\Persistence\Queries\SqlQueryResultSetBlock.cs" Link="Persistence\Queries\SqlQueryResultSetBlock.cs" />
+      <Compile Include="..\Foundation\Persistence\Queries\SqlQueryBlocks.cs" Link="Persistence\Queries\SqlQueryBlocks.cs" />
+      <Compile Include="..\Foundation\Utilities\SqlUtilities.cs" Link="Utilities\SqlUtilities.cs" />
+    </ItemGroup>
 </Project>

--- a/src/Tests.Foundation/Foundation/Utilities/SqlUtilitiesTests.cs
+++ b/src/Tests.Foundation/Foundation/Utilities/SqlUtilitiesTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using IOKode.OpinionatedFramework.Persistence.Queries;
 using IOKode.OpinionatedFramework.Utilities;
 
@@ -21,10 +22,59 @@ public class SqlUtilitiesTests
         Assert.Equal(new[] { "generate", "parameter string name", "OnlyActive" }, directives);
     }
 
+    [Fact]
+    public void GetQueryBlocks_WithoutResultSet_ReturnsAllDirectivesAsGlobalAndImplicitResultSetDirectives()
+    {
+        var sql = """
+                  -- @generate
+                  -- @tenant_scoped
+                  -- @cardinality one
+                  -- @result int id
+                  select id from users
+                  """;
+
+        var queryBlocks = SqlUtilities.GetQueryBlocks(sql);
+
+        Assert.False(queryBlocks.HasExplicitResultSets);
+        Assert.Equal(new[] { "generate", "tenant_scoped", "cardinality one", "result int id" }, queryBlocks.GlobalDirectives);
+        Assert.Single(queryBlocks.ResultSets);
+        Assert.Equal(queryBlocks.GlobalDirectives, queryBlocks.ResultSets.Single().Directives);
+    }
+
+    [Fact]
+    public void GetQueryBlocks_WithResultSets_SplitsDirectivesByPosition()
+    {
+        var sql = """
+                  -- @generate
+                  -- @tenant_scoped
+
+                  -- @result_set users
+                  -- @only_active
+                  -- @cardinality zero_or_more
+                  -- @result int id
+                  select id from users;
+
+                  -- @result_set total
+                  -- @cache 30s
+                  -- @cardinality one
+                  -- @scalar_result int total
+                  select count(*) as total from users;
+                  """;
+
+        var queryBlocks = SqlUtilities.GetQueryBlocks(sql);
+
+        Assert.True(queryBlocks.HasExplicitResultSets);
+        Assert.Equal(new[] { "generate", "tenant_scoped" }, queryBlocks.GlobalDirectives);
+        Assert.Equal(2, queryBlocks.ResultSets.Count);
+        Assert.Equal(new[] { "result_set users", "only_active", "cardinality zero_or_more", "result int id" }, queryBlocks.ResultSets[0].Directives);
+        Assert.Equal(new[] { "result_set total", "cache 30s", "cardinality one", "scalar_result int total" }, queryBlocks.ResultSets[1].Directives);
+    }
+
     [Theory]
     [InlineData(QueryCardinality.ZeroOrMore, null)]
-    [InlineData(QueryCardinality.One, "single")]
-    [InlineData(QueryCardinality.ZeroOrOne, "single_or_default")]
+    [InlineData(QueryCardinality.ZeroOrMore, "cardinality zero_or_more")]
+    [InlineData(QueryCardinality.One, "cardinality one")]
+    [InlineData(QueryCardinality.ZeroOrOne, "cardinality zero_or_one")]
     public void GetCardinality_ReturnsCardinalityFromDirectives(QueryCardinality expectedCardinality,
         string? directive)
     {
@@ -38,12 +88,13 @@ public class SqlUtilitiesTests
     [Fact]
     public void GetCardinality_ThrowsForIncompatibleCardinalityDirectives()
     {
-        Assert.Throws<InvalidOperationException>(() => SqlUtilities.GetCardinality(new[] { "single", "single_or_default" }));
+        Assert.Throws<QueryDefinitionException>(() => SqlUtilities.GetCardinality(new[] { "cardinality one", "cardinality zero_or_one" }));
     }
 
     [Theory]
     [InlineData("first")]
     [InlineData("first_or_default")]
+    [InlineData("cardinality invalid")]
     public void GetCardinality_IgnoresUnsupportedCardinalityDirectives(string directive)
     {
         var cardinality = SqlUtilities.GetCardinality(new[] { directive });

--- a/src/Tests.NHibernate.Postgres/Config/Entities/AddressType.cs
+++ b/src/Tests.NHibernate.Postgres/Config/Entities/AddressType.cs
@@ -11,7 +11,7 @@ namespace IOKode.OpinionatedFramework.Tests.NHibernate.Postgres.Config.Entities;
 
 public sealed class AddressType : IUserType
 {
-    private static readonly SqlType[] sqlTypes = [new(DbType.Object)];
+    private static readonly SqlType[] sqlTypes = new[] { new SqlType(DbType.Object) };
 
     public bool IsMutable => false;
 

--- a/src/Tests.NHibernate.Postgres/Config/Queries/GetUserIfExists.sql
+++ b/src/Tests.NHibernate.Postgres/Config/Queries/GetUserIfExists.sql
@@ -1,7 +1,7 @@
 -- @generate
 -- @parameter string name
+-- @cardinality zero_or_one
 -- @result int id
 -- @result string name
--- @single_or_default
 
 select id, name from users where name = :name;

--- a/src/Tests.NHibernate.Postgres/Config/Queries/GetUserName.sql
+++ b/src/Tests.NHibernate.Postgres/Config/Queries/GetUserName.sql
@@ -2,7 +2,7 @@
 -- @using IOKode.OpinionatedFramework.Resources.Attributes
 -- @attribute [RetrieveResource("active user", key: "name")]
 -- @parameter string id
+-- @cardinality one
 -- @result string name
--- @single
 
 select name from users where id = :id;

--- a/src/Tests.NHibernate.Postgres/Config/Queries/ListPaginatedUsersWithTotal.sql
+++ b/src/Tests.NHibernate.Postgres/Config/Queries/ListPaginatedUsersWithTotal.sql
@@ -1,9 +1,17 @@
 -- @generate
+-- @custom_global_directive
 -- @parameter int skip
 -- @parameter int take
--- @result string name
--- @count total
--- @query_result_name UserPaginated
 
-select name, count(*) OVER() as total from users
+-- @result_set total
+-- @custom_total_directive
+-- @cardinality one
+-- @scalar_result int total
+select count(*) as total from users;
+
+-- @result_set users
+-- @custom_users_directive
+-- @cardinality zero_or_more
+-- @result string name
+select name from users
 limit :take offset :skip;

--- a/src/Tests.NHibernate.Postgres/Config/Queries/UserExists.sql
+++ b/src/Tests.NHibernate.Postgres/Config/Queries/UserExists.sql
@@ -1,7 +1,7 @@
 -- @generate
 -- @parameter string name
+-- @cardinality zero_or_one
 -- @result int id
 -- @map -> bool
--- @single_or_default
 
 select id from users where name = :name;

--- a/src/Tests.NHibernate.Postgres/Config/Queries/UsersCountWithFilters.sql
+++ b/src/Tests.NHibernate.Postgres/Config/Queries/UsersCountWithFilters.sql
@@ -3,7 +3,8 @@
 -- @parameter string? name
 -- @parameter Address? address
 -- @map UsersFilters? filters -> int
--- @count
+-- @cardinality one
+-- @result int count
 
 select count(*) as "count"
 from users

--- a/src/Tests.NHibernate.Postgres/Config/Queries/UsersCountWithFiltersQuery.cs
+++ b/src/Tests.NHibernate.Postgres/Config/Queries/UsersCountWithFiltersQuery.cs
@@ -20,8 +20,8 @@ public partial class UsersCountWithFiltersQuery
         };
     }
 
-    private partial int MapResult(IReadOnlyCollection<UsersCountWithFiltersQueryResultWithCount> rawResults)
+    private partial int MapResult(IReadOnlyCollection<UsersCountWithFiltersQueryResult> rawResults)
     {
-        return rawResults.FirstOrDefault()?.Count ?? 0;
+        return rawResults.First().Count;
     }
 }

--- a/src/Tests.NHibernate.Postgres/Config/Queries/UsersScalarCount.sql
+++ b/src/Tests.NHibernate.Postgres/Config/Queries/UsersScalarCount.sql
@@ -1,0 +1,6 @@
+-- @generate
+-- @cardinality one
+-- @scalar_result int count
+
+select count(*) as "count"
+from users

--- a/src/Tests.NHibernate.Postgres/QueryExecutorMiddlewareTests.cs
+++ b/src/Tests.NHibernate.Postgres/QueryExecutorMiddlewareTests.cs
@@ -81,6 +81,72 @@ public class QueryExecutorMiddlewareTests(NHibernateTestsFixture fixture, ITestO
     }
 
     [Fact]
+    public async Task MiddlewareCanModifyImplicitResultSetQuery_Success()
+    {
+        // Arrange
+        await npgsqlClient.ExecuteAsync("INSERT INTO Users (id, name, email, is_active) VALUES ('1', 'Test User', 'test@example.com', true);");
+        await npgsqlClient.ExecuteAsync("INSERT INTO Users (id, name, email, is_active) VALUES ('2', 'Another User', 'another@example.com', true);");
+
+        var queryExecutor = CreateExecutor(new ImplicitResultSetQueryModifierMiddleware());
+
+        // Act
+        var result = await queryExecutor.QueryAsync<UserDto>("SELECT id, name, email, is_active FROM Users", null);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("Test User", result.First().Name);
+        Assert.False(ImplicitResultSetQueryModifierMiddleware.HasMultipleResultSets);
+        Assert.Single(ImplicitResultSetQueryModifierMiddleware.ResultSets);
+        Assert.Null(ImplicitResultSetQueryModifierMiddleware.ResultSets.Single().Name);
+    }
+
+    [Fact]
+    public async Task MiddlewareCanModifyNamedResultSetQuery_Success()
+    {
+        // Arrange
+        await npgsqlClient.ExecuteAsync("INSERT INTO Users (id, name, email, is_active) VALUES ('1', 'Active User', 'active@example.com', true);");
+        await npgsqlClient.ExecuteAsync("INSERT INTO Users (id, name, email, is_active) VALUES ('2', 'Inactive User', 'inactive@example.com', false);");
+
+        var queryExecutor = CreateExecutor(new NamedResultSetQueryModifierMiddleware());
+        var resultSets = new[]
+        {
+            new QueryResultSet
+            {
+                Name = "active_users",
+                RawSql = "SELECT id, name, email, is_active FROM Users",
+                Directives = new[] { "result_set active_users" },
+                Cardinality = QueryCardinality.ZeroOrMore,
+                Shape = QueryResultShape.Object,
+                ResultType = typeof(UserDto),
+            },
+            new QueryResultSet
+            {
+                Name = "inactive_users",
+                RawSql = "SELECT id, name, email, is_active FROM Users",
+                Directives = new[] { "result_set inactive_users" },
+                Cardinality = QueryCardinality.ZeroOrMore,
+                Shape = QueryResultShape.Object,
+                ResultType = typeof(UserDto),
+            }
+        };
+
+        // Act
+        var rawResults = await queryExecutor.QueryResultSetsAsync(resultSets, new[] { "global_directive" }, null);
+
+        // Assert
+        var activeUsers = Assert.IsAssignableFrom<IReadOnlyCollection<UserDto>>(rawResults[0]);
+        var inactiveUsers = Assert.IsAssignableFrom<IReadOnlyCollection<UserDto>>(rawResults[1]);
+
+        Assert.True(NamedResultSetQueryModifierMiddleware.HasMultipleResultSets);
+        Assert.Equal(new[] { "global_directive" }, NamedResultSetQueryModifierMiddleware.Directives);
+        Assert.Equal(new[] { "active_users", "inactive_users" }, NamedResultSetQueryModifierMiddleware.ResultSets.Select(resultSet => resultSet.Name));
+        Assert.Single(activeUsers);
+        Assert.Equal("Active User", activeUsers.Single().Name);
+        Assert.Single(inactiveUsers);
+        Assert.Equal("Inactive User", inactiveUsers.Single().Name);
+    }
+
+    [Fact]
     public async Task MiddlewareCanHandleExceptions_Success()
     {
         // Arrange
@@ -93,6 +159,17 @@ public class QueryExecutorMiddlewareTests(NHibernateTestsFixture fixture, ITestO
 
         // Assert
         Assert.True(ExceptionHandlingMiddleware.ExceptionHandled);
+    }
+
+    [Fact]
+    public async Task MiddlewareCannotReadResultsBeforeExecution()
+    {
+        // Arrange
+        var queryExecutor = CreateExecutor(new ReadResultsBeforeExecutionMiddleware());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            queryExecutor.QueryAsync<UserDto>("SELECT id, name, email, is_active FROM Users", null));
     }
 
     [Fact]
@@ -268,7 +345,43 @@ public class QueryModifierMiddleware : QueryMiddleware
     public override async Task ExecuteAsync(IQueryExecutionContext executionContext,
         InvokeNextMiddlewareDelegate nextAsync)
     {
-        executionContext.RawQuery += " WHERE id = '1'";
+        executionContext.ResultSets.Single().RawQuery += " WHERE id = '1'";
+
+        await nextAsync();
+    }
+}
+
+public class ImplicitResultSetQueryModifierMiddleware : QueryMiddleware
+{
+    public static bool HasMultipleResultSets { get; private set; }
+    public static IReadOnlyList<IQueryResultSetExecutionContext> ResultSets { get; private set; } = Array.Empty<IQueryResultSetExecutionContext>();
+
+    public override async Task ExecuteAsync(IQueryExecutionContext executionContext,
+        InvokeNextMiddlewareDelegate nextAsync)
+    {
+        HasMultipleResultSets = executionContext.HasMultipleResultSets;
+        ResultSets = executionContext.ResultSets;
+        executionContext.ResultSets.Single().RawQuery += " WHERE id = '1'";
+
+        await nextAsync();
+    }
+}
+
+public class NamedResultSetQueryModifierMiddleware : QueryMiddleware
+{
+    public static bool HasMultipleResultSets { get; private set; }
+    public static IReadOnlyList<string> Directives { get; private set; } = Array.Empty<string>();
+    public static IReadOnlyList<IQueryResultSetExecutionContext> ResultSets { get; private set; } = Array.Empty<IQueryResultSetExecutionContext>();
+
+    public override async Task ExecuteAsync(IQueryExecutionContext executionContext,
+        InvokeNextMiddlewareDelegate nextAsync)
+    {
+        HasMultipleResultSets = executionContext.HasMultipleResultSets;
+        Directives = executionContext.Directives.ToList();
+        ResultSets = executionContext.ResultSets;
+
+        executionContext.ResultSets.Single(resultSet => resultSet.Name == "active_users").RawQuery += " WHERE is_active = true";
+        executionContext.ResultSets.Single(resultSet => resultSet.Name == "inactive_users").RawQuery += " WHERE is_active = false";
 
         await nextAsync();
     }
@@ -292,6 +405,16 @@ public class ExceptionHandlingMiddleware : QueryMiddleware
     }
 }
 
+public class ReadResultsBeforeExecutionMiddleware : QueryMiddleware
+{
+    public override Task ExecuteAsync(IQueryExecutionContext executionContext,
+        InvokeNextMiddlewareDelegate nextAsync)
+    {
+        _ = executionContext.Results;
+        return nextAsync();
+    }
+}
+
 public class OnlyActiveDirectiveProcessingMiddleware : QueryMiddleware
 {
     public override async Task ExecuteAsync(IQueryExecutionContext executionContext,
@@ -299,8 +422,7 @@ public class OnlyActiveDirectiveProcessingMiddleware : QueryMiddleware
     {
         if (executionContext.Directives.Contains("OnlyActive"))
         {
-            string modifiedQuery = executionContext.RawQuery + " WHERE is_active = true";
-            executionContext.RawQuery = modifiedQuery;
+            executionContext.ResultSets.Single().RawQuery += " WHERE is_active = true";
         }
 
         await nextAsync();

--- a/src/Tests.NHibernate.Postgres/QueryObjectTests.cs
+++ b/src/Tests.NHibernate.Postgres/QueryObjectTests.cs
@@ -18,7 +18,7 @@ namespace IOKode.OpinionatedFramework.Tests.NHibernate.Postgres;
 public class QueryObjectTests(NHibernateTestsFixture fixture, ITestOutputHelper outputHelper) : NHibernateTestsBase(fixture, outputHelper)
 {
     [Fact]
-    public async Task Single()
+    public async Task One()
     {
         // Arrange
         await npgsqlClient.ExecuteAsync("INSERT INTO users (id, name) VALUES ('1', 'Ivan');");
@@ -30,6 +30,11 @@ public class QueryObjectTests(NHibernateTestsFixture fixture, ITestOutputHelper 
         Assert.Equal("Ivan", result.Name);
         Assert.Contains("generate", query.Directives);
         Assert.Contains("parameter string id", query.Directives);
+        Assert.Contains("cardinality one", query.Directives);
+        Assert.Single(query.ResultSets);
+        Assert.Null(query.ResultSets[0].Name);
+        Assert.Contains("cardinality one", query.ResultSets[0].Directives);
+        Assert.Contains("result string name", query.ResultSets[0].Directives);
         Assert.NotNull(attribute);
         Assert.Equal("active user", attribute.Resource);
         Assert.Equal("name", attribute.Key);
@@ -37,7 +42,7 @@ public class QueryObjectTests(NHibernateTestsFixture fixture, ITestOutputHelper 
     }
 
     [Fact]
-    public async Task SingleOrDefault()
+    public async Task ZeroOrOne()
     {
         // Arrange
         await npgsqlClient.ExecuteAsync("INSERT INTO users (id, name) VALUES ('1', 'Ivan');");
@@ -55,7 +60,7 @@ public class QueryObjectTests(NHibernateTestsFixture fixture, ITestOutputHelper 
     }
 
     [Fact]
-    public async Task Many()
+    public async Task ZeroOrMore()
     {
         // Arrange
         await npgsqlClient.ExecuteAsync("INSERT INTO users (id, name, address) VALUES (1, 'Ivan', ('Fake St. 123', 'Springfield', 'USA'));");
@@ -105,7 +110,7 @@ public class QueryObjectTests(NHibernateTestsFixture fixture, ITestOutputHelper 
 
         // Assert
         Assert.Equal(3, results.Count);
-        Assert.Equal([3, 2, 1], results.Select(user => user.Id));
+        Assert.Equal(new[] { 3, 2, 1 }, results.Select(user => user.Id));
     }
 
     [Fact]
@@ -132,9 +137,9 @@ public class QueryObjectTests(NHibernateTestsFixture fixture, ITestOutputHelper 
         var usersWithFilters2 = await new GetUsersWithFiltersQuery { Filters = filters2 }.InvokeAsync(CancellationToken.None);
 
         // Assert
-        Assert.Equal([1, 2, 3, 4], usersWithNoFilters.Select(user => user.Id));
-        Assert.Equal([1], usersWithFilters1.Select(user => user.Id));
-        Assert.Equal([1, 2], usersWithFilters2.Select(user => user.Id));
+        Assert.Equal(new[] { 1, 2, 3, 4 }, usersWithNoFilters.Select(user => user.Id));
+        Assert.Equal(new[] { 1 }, usersWithFilters1.Select(user => user.Id));
+        Assert.Equal(new[] { 1, 2 }, usersWithFilters2.Select(user => user.Id));
     }
 
     [Fact]
@@ -182,7 +187,21 @@ public class QueryObjectTests(NHibernateTestsFixture fixture, ITestOutputHelper 
     }
 
     [Fact]
-    public async Task Count_WithQueryResultName()
+    public async Task ScalarResult_ReturnsSingleValue()
+    {
+        // Arrange
+        await npgsqlClient.ExecuteAsync("INSERT INTO users (id, name) VALUES ('1', 'Ivan');");
+        await npgsqlClient.ExecuteAsync("INSERT INTO users (id, name) VALUES ('2', 'Marta');");
+
+        // Act
+        var count = await new UsersScalarCountQuery().InvokeAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public async Task MultipleResultSets_WithScalarAndCollection()
     {
         // Arrange
         await npgsqlClient.ExecuteAsync("INSERT INTO users (id, name) VALUES ('1', 'Ivan');");
@@ -196,18 +215,32 @@ public class QueryObjectTests(NHibernateTestsFixture fixture, ITestOutputHelper 
         var page1 = await new ListPaginatedUsersWithTotalQuery { Skip = 0, Take = 2 }.InvokeAsync(CancellationToken.None);
         var page2 = await new ListPaginatedUsersWithTotalQuery { Skip = 2, Take = 1 }.InvokeAsync(CancellationToken.None);
         var page3 = await new ListPaginatedUsersWithTotalQuery { Skip = 3, Take = 3 }.InvokeAsync(CancellationToken.None);
+        var page4 = await new ListPaginatedUsersWithTotalQuery { Skip = 6, Take = 3 }.InvokeAsync(CancellationToken.None);
 
         // Assert
-        Assert.Equal(6, page1.Count);
-        Assert.Equal(2, page1.Results.Count);
-        Assert.True(page1.Results.All(result => result.Name == "Ivan"));
+        var query = new ListPaginatedUsersWithTotalQuery { Skip = 0, Take = 1 };
+        Assert.Contains("custom_global_directive", query.Directives);
+        Assert.DoesNotContain("custom_total_directive", query.Directives);
+        Assert.DoesNotContain("custom_users_directive", query.Directives);
+        Assert.Equal(new[] { "total", "users" }, query.ResultSets.Select(resultSet => resultSet.Name));
+        Assert.Contains("custom_total_directive", query.ResultSets[0].Directives);
+        Assert.Contains("scalar_result int total", query.ResultSets[0].Directives);
+        Assert.Contains("custom_users_directive", query.ResultSets[1].Directives);
+        Assert.Contains("result string name", query.ResultSets[1].Directives);
+
+        Assert.Equal(6, page1.Total);
+        Assert.Equal(2, page1.Users.Count);
+        Assert.True(page1.Users.All(result => result.Name == "Ivan"));
         
-        Assert.Equal(6, page2.Count);
-        Assert.Single(page2.Results);
-        Assert.Equal("Marta", page2.Results.Single().Name);
+        Assert.Equal(6, page2.Total);
+        Assert.Single(page2.Users);
+        Assert.Equal("Marta", page2.Users.Single().Name);
         
-        Assert.Equal(6, page3.Count);
-        Assert.Equal(3, page3.Results.Count);
-        Assert.Equal(["Marta", "Javier", "Javier"], page3.Results.Select(result => result.Name));
+        Assert.Equal(6, page3.Total);
+        Assert.Equal(3, page3.Users.Count);
+        Assert.Equal(new[] { "Marta", "Javier", "Javier" }, page3.Users.Select(result => result.Name));
+
+        Assert.Equal(6, page4.Total);
+        Assert.Empty(page4.Users);
     }
 }

--- a/src/Tests.Resources/ResourceNotFoundQuery.sql
+++ b/src/Tests.Resources/ResourceNotFoundQuery.sql
@@ -2,8 +2,8 @@
 -- @using IOKode.OpinionatedFramework.Resources.Attributes
 -- @attribute [RetrieveResource("not found query", "id")]
 -- @parameter int id
+-- @cardinality one
 -- @result string name
--- @single
 
 select unnest(array['resource1', 'resource2', 'resource3']) as name
 where :id = -1;

--- a/src/Tests.Resources/RetrieveUserFullNameByName.sql
+++ b/src/Tests.Resources/RetrieveUserFullNameByName.sql
@@ -2,7 +2,7 @@
 -- @using IOKode.OpinionatedFramework.Resources.Attributes
 -- @attribute [RetrieveResource("user/name", "name")]
 -- @parameter string name
+-- @cardinality one
 -- @result string name
--- @single
 
 select :name as name;


### PR DESCRIPTION
## What changes

This PR adds support for **generated SQL query objects with multiple result sets**.

Previously, a generated query assumed a single result set and the public result was derived from one collection of rows. With this change, a query can declare multiple `@result_set` blocks. Each block has its own SQL, directives, cardinality and result shape. The generator then composes a public result type with one property per result set.

Example:

```sql
-- @generate
-- @parameter int skip
-- @parameter int take

-- @result_set total
-- @cardinality one
-- @scalar_result int total
select count(*) as total from users;

-- @result_set users
-- @cardinality zero_or_more
-- @result string name
select name from users
limit :take offset :skip;
```

This generates a composed result similar to:

```csharp
public partial record ListPaginatedUsersWithTotalQueryResult
{
    public required int Total { get; init; }
    public required IReadOnlyCollection<UserResult> Users { get; init; }
}
```

## New directives

### `@result_set <name>`

Marks the beginning of a result set block. The presence of at least one `@result_set` enables multiple-result-set mode.

The name is used to generate:

- the property name in the composed result;
- the row type name, using Humanizer to singularize/pascalize it.

For example:

```sql
-- @result_set user_summaries
```

produces a `UserSummaries` property and a `UserSummaryResult` row type.

### `@cardinality <value>`

Defines the expected cardinality of the result set:

- `zero_or_more`
- `one`
- `zero_or_one`

This replaces the previous `@single` and `@single_or_default` directives.

### `@scalar_result <type> <column>`

Declares that the result set returns a single value per row instead of mapping each row to an object/DTO.

This removes the need for `MapResult` when the query only needs to return a simple value:

```sql
-- @generate
-- @cardinality one
-- @scalar_result int count

select count(*) as count
from users;
```

The generated query returns `int` directly.

`@scalar_result` is mutually exclusive with `@result` within the same result set.

## Global and local directives

Directives are no longer classified by name. They are classified by position:

- when `@result_set` is used, directives before the first `@result_set` are global;
- directives inside each result set block belong to that result set;
- when no `@result_set` is used, all directives are global and also belong to the implicit result set.

This allows custom middleware directives to keep working without the generator needing to know about them.

## NHibernate execution

Multiple-result-set execution is implemented with NHibernate, not with Dapper or direct Npgsql access.

Each result set is executed as a separate `ISQLQuery` inside an `IQueryBatch`, preserving support for:

- `AddScalar(...)`;
- result transformers;
- NHibernate `IUserType`;
- executor alias and parameter transformations.

This is important so complex types declared in `@result` continue to go through NHibernate's type system.

## Middleware execution context

The query execution context now exposes result sets explicitly:

- `HasMultipleResultSets`
- `ResultSets`

Each result set exposes:

- `Name`
- `Directives`
- `Cardinality`
- `Shape`
- `ResultType`
- `ScalarColumnName`
- `RawQuery`
- `Results`

The global `RawQuery` is read-only metadata. If a middleware needs to modify SQL, it must modify `ResultSets[i].RawQuery`.

Single-result-set queries expose one implicit result set with `Name == null`.

## Breaking changes

This change intentionally removes or replaces several previous pieces:

- removes `QueryResultsWithCount`;
- removes `@count` for now;
- removes `@query_result_name`;
- replaces `@single` and `@single_or_default` with `@cardinality one` and `@cardinality zero_or_one`;
- generated queries now expose result set metadata.

The project is still early-stage, so these breaking changes are intentional.

## Tests added/updated

This PR adds or updates coverage for:

- scalar queries with `@scalar_result`;
- multiple-result-set queries with scalar + collection result sets;
- empty pages while preserving total count in a separate result set;
- global/local directives, including custom directives;
- middlewares modifying explicit and implicit result sets;
- accessing `Results` before execution;
- existing NHibernate `IUserType` / complex type behavior.