### PR TITLE
Support custom mapping for queries with multiple result sets

### DIFF
--- a/src/Foundation/Persistence/Queries/QueryExecutorExtensions.cs
+++ b/src/Foundation/Persistence/Queries/QueryExecutorExtensions.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -36,38 +38,55 @@ public static class QueryExecutorExtensions
             ?? throw new QueryDefinitionException($"Query type '{queryType.FullName}' does not declare MapResult.");
         var parameters = mapParametersMethod.Invoke(query, Array.Empty<object?>());
         var rawResultSets = await queryExecutor.QueryResultSetsAsync(query.ResultSets, query.Directives, parameters, null, cancellationToken);
-        var mapResultArgument = GetMapResultArgument(mapResultMethod, queryType, rawResultSets);
+        var mapResultArguments = GetMapResultArguments(mapResultMethod, queryType, query.ResultSets, rawResultSets);
 
-        return (TResult) mapResultMethod.Invoke(query, new[] { mapResultArgument })!;
+        return (TResult) mapResultMethod.Invoke(query, mapResultArguments)!;
     }
 
     /// <summary>
-    /// Gets the raw row type from the generated <c>MapResult</c> method signature.
+    /// Gets the shaped raw result values for the generated <c>MapResult</c> method signature.
     /// </summary>
-    private static object GetMapResultArgument(MethodInfo mapResultMethod, Type queryType, IReadOnlyList<object> rawResultSets)
+    private static object?[] GetMapResultArguments(MethodInfo mapResultMethod, Type queryType,
+        IReadOnlyList<QueryResultSet> resultSets, IReadOnlyList<object> rawResultSets)
     {
         var parameters = mapResultMethod.GetParameters();
-        if (parameters.Length != 1)
+        if (parameters.Length != resultSets.Count)
         {
-            throw new QueryDefinitionException($"Query type '{queryType.FullName}' must declare MapResult with a single parameter.");
+            throw new QueryDefinitionException($"Query type '{queryType.FullName}' must declare MapResult with one parameter per result set.");
         }
 
-        var rawResultsType = parameters[0].ParameterType;
-        if (rawResultsType == typeof(IReadOnlyList<object>))
+        if (rawResultSets.Count != resultSets.Count)
         {
-            return rawResultSets;
+            throw new QueryDefinitionException($"Query type '{queryType.FullName}' returned an unexpected number of result sets.");
         }
 
-        if (rawResultsType.IsGenericType && rawResultsType.GetGenericTypeDefinition() == typeof(IReadOnlyCollection<>))
+        var arguments = new object?[resultSets.Count];
+        for (int i = 0; i < resultSets.Count; i++)
         {
-            if (rawResultSets.Count != 1)
-            {
-                throw new QueryDefinitionException($"Query type '{queryType.FullName}' must declare MapResult with IReadOnlyList<object> for multiple result sets.");
-            }
-
-            return rawResultSets[0];
+            arguments[i] = GetMapResultArgument(resultSets[i], rawResultSets[i]);
         }
 
-        throw new QueryDefinitionException($"Query type '{queryType.FullName}' must declare MapResult with an IReadOnlyCollection<T> or IReadOnlyList<object> parameter.");
+        return arguments;
+    }
+
+    private static object? GetMapResultArgument(QueryResultSet resultSet, object rawResultSet)
+    {
+        return resultSet.Cardinality switch
+        {
+            QueryCardinality.One => AsEnumerable(rawResultSet).Cast<object>().First(),
+            QueryCardinality.ZeroOrOne => AsEnumerable(rawResultSet).Cast<object>().FirstOrDefault(),
+            QueryCardinality.ZeroOrMore => rawResultSet,
+            _ => throw new QueryDefinitionException($"Unsupported query cardinality: {resultSet.Cardinality}.")
+        };
+    }
+
+    private static IEnumerable AsEnumerable(object rawResultSet)
+    {
+        if (rawResultSet is IEnumerable enumerable)
+        {
+            return enumerable;
+        }
+
+        throw new QueryDefinitionException("Raw result set must be enumerable.");
     }
 }

--- a/src/MSBuild/Base.props
+++ b/src/MSBuild/Base.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup Label="Build settings">
         <TargetFramework>net10.0</TargetFramework>
-        <Version>0.38.0-dev</Version>
+        <Version>0.39.0-dev</Version>
         <EnsuringVersion>1.2.2</EnsuringVersion>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/SourceGenerators.SqlQueryObjects/QueryObjectsGenerator.CodeGeneraton.cs
+++ b/src/SourceGenerators.SqlQueryObjects/QueryObjectsGenerator.CodeGeneraton.cs
@@ -51,7 +51,7 @@ public partial class QueryObjectsGenerator
         public bool HasMappedParameters { get; private set; }
         public bool HasMappedResult => !string.IsNullOrWhiteSpace(MappedQueryResultString);
         public bool RequiresCustomMapParameters => HasMapDirective && HasMappedParameters;
-        public bool RequiresCustomMapResult => !HasExplicitResultSets && HasMapDirective && (!HasMappedParameters || HasMappedResult);
+        public bool RequiresCustomMapResult => HasMapDirective && (!HasMappedParameters || HasMappedResult);
 
         public string Name => Path.GetFileNameWithoutExtension(SqlFile.FilePath);
         public string ClassName => Name.EndsWith("Query") ? Name : $"{Name}Query";
@@ -80,6 +80,8 @@ public partial class QueryObjectsGenerator
         public string QueryResultString => HasExplicitResultSets
             ? CompositeQueryResultClassName
             : SingleResultSet.ResultString;
+
+        public string MapResultParametersString => string.Join(", ", ResultSets.Select(resultSet => $"{resultSet.ResultString} {resultSet.MapResultParameterName}"));
 
         public string InvokeResultString => RequiresCustomMapResult && !string.IsNullOrWhiteSpace(MappedQueryResultString)
             ? MappedQueryResultString!
@@ -225,6 +227,7 @@ public partial class QueryObjectsGenerator
             QueryCardinality.ZeroOrOne => $"{ElementType}?",
             _ => $"IReadOnlyCollection<{ElementType}>"
         };
+        public string MapResultParameterName => Name == null ? "result" : PropertyName.Camelize();
 
         public static ResultSetDefinition ParseImplicit(SqlQueryResultSetBlock block, string objectResultClassName)
         {
@@ -401,22 +404,21 @@ public partial class QueryObjectsGenerator
             }
             {{~ end ~}}
 
-            {{~ if HasExplicitResultSets ~}}
-            private {{ InvokeResultString }} MapResult(IReadOnlyList<object> rawResultSets)
+            {{~ if RequiresCustomMapResult ~}}
+            private partial {{ InvokeResultString }} MapResult({{ MapResultParametersString }});
+            {{~ else ~}}
+            private {{ InvokeResultString }} MapResult({{ MapResultParametersString }})
             {
+                {{~ if HasExplicitResultSets ~}}
                 return new {{ InvokeResultString }}
                 {
                     {{~ for result_set in ResultSets ~}}
-                    {{ result_set.PropertyName }} = Map{{ result_set.Cardinality }}(GetResultSet<{{ result_set.ElementType }}>(rawResultSets, {{ result_set.Index }})),
+                    {{ result_set.PropertyName }} = {{ result_set.MapResultParameterName }},
                     {{~ end ~}}
                 };
-            }
-            {{~ else if RequiresCustomMapResult ~}}
-            private partial {{ InvokeResultString }} MapResult(IReadOnlyCollection<{{ SingleResultSet.ElementType }}> rawResults);
-            {{~ else ~}}
-            private {{ InvokeResultString }} MapResult(IReadOnlyCollection<{{ SingleResultSet.ElementType }}> rawResults)
-            {
-                return Map{{ SingleResultSet.Cardinality }}(rawResults);
+                {{~ else ~}}
+                return {{ SingleResultSet.MapResultParameterName }};
+                {{~ end ~}}
             }
             {{~ end ~}}
 
@@ -442,7 +444,7 @@ public partial class QueryObjectsGenerator
 
         }
 
-        {{~ if HasExplicitResultSets ~}}
+        {{~ if HasExplicitResultSets && !HasMappedResult ~}}
         {{ QueryClassAccessor }} partial record {{ CompositeQueryResultClassName }}
         {
             {{~ for result_set in ResultSets ~}}

--- a/src/Tests.NHibernate.Postgres/Config/Queries/ListMappedPaginatedUsersWithTotal.sql
+++ b/src/Tests.NHibernate.Postgres/Config/Queries/ListMappedPaginatedUsersWithTotal.sql
@@ -1,0 +1,22 @@
+-- @generate
+-- @parameter string? name
+-- @parameter int skip
+-- @parameter int take
+-- @map MappedUsersPageFilter filter -> MappedUsersPage
+
+-- @result_set filtered_total
+-- @cardinality one
+-- @scalar_result int total
+select count(*) as total
+from users
+where name = coalesce(:name, name);
+
+-- @result_set filtered_users
+-- @cardinality zero_or_more
+-- @result int id
+-- @result string name
+select id, name
+from users
+where name = coalesce(:name, name)
+order by id
+limit :take offset :skip;

--- a/src/Tests.NHibernate.Postgres/Config/Queries/ListMappedPaginatedUsersWithTotalQuery.cs
+++ b/src/Tests.NHibernate.Postgres/Config/Queries/ListMappedPaginatedUsersWithTotalQuery.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace IOKode.OpinionatedFramework.Tests.NHibernate.Postgres.Config.Queries;
+
+public record MappedUsersPageFilter
+{
+    public string? Name { get; init; }
+    public int Skip { get; init; }
+    public int Take { get; init; }
+}
+
+public record MappedUsersPage
+{
+    public required int Total { get; init; }
+    public required IReadOnlyCollection<MappedUser> Users { get; init; }
+}
+
+public record MappedUser
+{
+    public required int Id { get; init; }
+    public required string Name { get; init; }
+}
+
+public partial class ListMappedPaginatedUsersWithTotalQuery
+{
+    private partial ListMappedPaginatedUsersWithTotalQueryParameters MapParameters()
+    {
+        return new ListMappedPaginatedUsersWithTotalQueryParameters
+        {
+            Name = Filter.Name,
+            Skip = Filter.Skip,
+            Take = Filter.Take
+        };
+    }
+
+    private partial MappedUsersPage MapResult(int filteredTotal, IReadOnlyCollection<FilteredUserResult> filteredUsers)
+    {
+        return new MappedUsersPage
+        {
+            Total = filteredTotal,
+            Users = filteredUsers
+                .Select(user => new MappedUser
+                {
+                    Id = user.Id,
+                    Name = user.Name
+                })
+                .ToList()
+        };
+    }
+}

--- a/src/Tests.NHibernate.Postgres/Config/Queries/ListUsersByDescendingIdQuery.cs
+++ b/src/Tests.NHibernate.Postgres/Config/Queries/ListUsersByDescendingIdQuery.cs
@@ -7,8 +7,8 @@ namespace IOKode.OpinionatedFramework.Tests.NHibernate.Postgres.Config.Queries;
 internal partial class ListUsersByDescendingIdQuery
 {
     private partial IReadOnlyCollection<ListUsersByDescendingIdQueryResult> MapResult(
-        IReadOnlyCollection<ListUsersByDescendingIdQueryResult> rawResults)
+        IReadOnlyCollection<ListUsersByDescendingIdQueryResult> result)
     {
-        return rawResults.OrderByDescending(result => result.Id).ToImmutableList();
+        return result.OrderByDescending(resultItem => resultItem.Id).ToImmutableList();
     }
 }

--- a/src/Tests.NHibernate.Postgres/Config/Queries/UserExistsQuery.cs
+++ b/src/Tests.NHibernate.Postgres/Config/Queries/UserExistsQuery.cs
@@ -1,13 +1,9 @@
-using System.Collections.Generic;
-using System.Linq;
-
 namespace IOKode.OpinionatedFramework.Tests.NHibernate.Postgres.Config.Queries;
 
 public partial class UserExistsQuery
 {
-    private partial bool MapResult(IReadOnlyCollection<UserExistsQueryResult> rawResults)
+    private partial bool MapResult(UserExistsQueryResult? result)
     {
-        var result = rawResults.FirstOrDefault();
         return result != null;
     }
 }

--- a/src/Tests.NHibernate.Postgres/Config/Queries/UsersCountWithFiltersQuery.cs
+++ b/src/Tests.NHibernate.Postgres/Config/Queries/UsersCountWithFiltersQuery.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-
 namespace IOKode.OpinionatedFramework.Tests.NHibernate.Postgres.Config.Queries;
 
 public record UsersFilters
@@ -20,8 +17,8 @@ public partial class UsersCountWithFiltersQuery
         };
     }
 
-    private partial int MapResult(IReadOnlyCollection<UsersCountWithFiltersQueryResult> rawResults)
+    private partial int MapResult(UsersCountWithFiltersQueryResult result)
     {
-        return rawResults.First().Count;
+        return result.Count;
     }
 }

--- a/src/Tests.NHibernate.Postgres/QueryObjectTests.cs
+++ b/src/Tests.NHibernate.Postgres/QueryObjectTests.cs
@@ -243,4 +243,30 @@ public class QueryObjectTests(NHibernateTestsFixture fixture, ITestOutputHelper 
         Assert.Equal(6, page4.Total);
         Assert.Empty(page4.Users);
     }
+
+    [Fact]
+    public async Task Map_WithParametersAndMultipleResultSets()
+    {
+        // Arrange
+        await npgsqlClient.ExecuteAsync("INSERT INTO users (id, name) VALUES ('1', 'Ivan');");
+        await npgsqlClient.ExecuteAsync("INSERT INTO users (id, name) VALUES ('2', 'Ivan');");
+        await npgsqlClient.ExecuteAsync("INSERT INTO users (id, name) VALUES ('3', 'Marta');");
+
+        // Act
+        var result = await new ListMappedPaginatedUsersWithTotalQuery
+        {
+            Filter = new MappedUsersPageFilter
+            {
+                Name = "Ivan",
+                Skip = 1,
+                Take = 1
+            }
+        }.InvokeAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, result.Total);
+        var user = Assert.Single(result.Users);
+        Assert.Equal(2, user.Id);
+        Assert.Equal("Ivan", user.Name);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #105.

This PR adds support for using `@map ->` on SQL query objects that declare multiple explicit `@result_set` blocks.

The source generator now exposes a single, cardinality-aware `MapResult` API instead of requiring custom mapping code to receive an untyped `IReadOnlyList<object>` for multiple result sets.

## What changed

### Cardinality-aware `MapResult` API

`MapResult` parameters are now shaped according to each result set cardinality:

- `@cardinality one` maps to `T`
- `@cardinality zero_or_one` maps to `T?`
- `@cardinality zero_or_more` maps to `IReadOnlyCollection<T>`

For multiple explicit result sets, the generated partial `MapResult` declaration receives one parameter per result set, in result set order. Parameter names are derived from the result set names.

Example shape:

```csharp
private partial MappedUsersPage MapResult(
    int filteredTotal,
    IReadOnlyCollection<FilteredUserResult> filteredUsers);
```

### No generated custom result mapper body

When a query uses `@map -> TResult`, the source generator now declares the partial `MapResult` method but does not generate an implementation body. The user-owned partial implementation is responsible for projecting the shaped raw results into the public result type.

Queries without custom result mapping still get a generated `MapResult` implementation.

### Invocation updates

`QueryExecutorExtensions` now invokes `MapResult` using one argument per declared result set. It builds those arguments from the raw executor result sets by applying the result set cardinality before invoking the generated/user partial method.

This keeps the untyped executor result container internal and avoids exposing `IReadOnlyList<object>` in the query object mapping API.

### Existing query mapping updates

Existing tests and partial query implementations were updated to the new cardinality-aware `MapResult` API:

- `zero_or_one` custom mapping now receives `T?`
- `one` custom mapping now receives `T`
- collection mappings continue to receive `IReadOnlyCollection<T>`

### Multiple result set mapping test coverage

A new integration query and test were added to cover:

- `@map params -> result` with multiple explicit result sets
- custom `MapParameters`
- custom `MapResult`
- one scalar result set plus one collection result set
- parameters applied across multiple result sets, including parameters used by only one result set

## Breaking change

This is a breaking change for custom `MapResult` implementations in query objects.

Previously, custom result mappings for a single result set received `IReadOnlyCollection<T>` regardless of cardinality. They now receive the cardinality-shaped value:

- `one`: `T`
- `zero_or_one`: `T?`
- `zero_or_more`: `IReadOnlyCollection<T>`

This aligns single and multiple result set mapping behavior behind one consistent API.

## Verification

Executed locally:

```bash
dotnet build src/Tests.NHibernate.Postgres/Tests.NHibernate.Postgres.csproj
dotnet test src/Tests.NHibernate.Postgres/Tests.NHibernate.Postgres.csproj --filter FullyQualifiedName~QueryObjectTests
```

Both passed.